### PR TITLE
Set CORS headers in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Upon successful installation, you should be able to access the admin panel at `/
 
 `script/test-server`
 
+### The environment flag
+
+When developing locally, it can be helpful to see error backtraces, disable template caching, have expanded request logs, and to allow cross-origin requests between the Ruby server and the Node server. By default, however, JekyllAdmin runs in `production` mode, meaning these development features are disabled.
+
+To enabled the development features, set the environmental variable `RACK_ENV` to `development`. When enabled, the `/_api/` endpoint will add `Access-Control-Allow-Origin: any` headers, and respond to `OPTIONS` pre-flight checks. This flag is set automatically when using the `script/test-server` command.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll/jekyll-admin. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop", "~> 0.35"
+  spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"
 end

--- a/lib/jekyll/admin.rb
+++ b/lib/jekyll/admin.rb
@@ -1,9 +1,9 @@
-require 'webrick'
-require 'sinatra'
-require 'sinatra/base'
+require "webrick"
+require "sinatra"
+require "sinatra/base"
 require "sinatra/json"
 require "sinatra/reloader"
-require 'json'
+require "json"
 require "jekyll"
 require "jekyll/admin/version"
 require "jekyll/admin/server"

--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -13,6 +13,14 @@ module Jekyll
         disable :allow_credentials
       end
 
+      ACCESS_CONTROL_ALLOW_HEADERS = %w(
+        X-Requested-With
+        X-HTTP-Method-Override
+        Content-Type
+        Cache-Control
+        Accept
+      ).freeze
+
       get "/" do
         json ROUTES.map { |route| ["#{route}_api", URI.join(base_url, "/_api/", route)] }.to_h
       end
@@ -21,7 +29,7 @@ module Jekyll
       options "*" do
         render_404 unless settings.development?
         response.headers["Allow"] = "HEAD,GET,PUT,POST,DELETE,OPTIONS"
-        response.headers["Access-Control-Allow-Headers"] = "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept"
+        response.headers["Access-Control-Allow-Headers"] = ACCESS_CONTROL_ALLOW_HEADERS.join(", ")
 
         status 200
       end

--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -5,10 +5,25 @@ module Jekyll
 
       configure :development do
         register Sinatra::Reloader
+        enable :logging
+
+        require "sinatra/cross_origin"
+        register Sinatra::CrossOrigin
+        enable  :cross_origin
+        disable :allow_credentials
       end
 
       get "/" do
         json ROUTES.map { |route| ["#{route}_api", URI.join(base_url, "/_api/", route)] }.to_h
+      end
+
+      # CORS preflight. See https://github.com/britg/sinatra-cross_origin#responding-to-options
+      options "*" do
+        render_404 unless settings.development?
+        response.headers["Allow"] = "HEAD,GET,PUT,POST,DELETE,OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept"
+
+        status 200
       end
 
       private

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,8 +10,12 @@ module Jekyll
           server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)
 
+          # Default Sinatra to "production" mode (surpress errors) unless
+          # otherwise specified by the `RACK_ENV` environmental variable
+          ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
+
           server.mount "/admin", Rack::Handler::WEBrick, Jekyll::Admin::StaticServer
-          server.mount "/_api", Rack::Handler::WEBrick, Jekyll::Admin::Server
+          server.mount "/_api",  Rack::Handler::WEBrick, Jekyll::Admin::Server
 
           Jekyll.logger.info "Server address:", server_address(server, opts)
           launch_browser server, opts if opts["open_url"]

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -10,16 +10,20 @@ module Jekyll
           server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)
 
+          jekyll_admin_monkey_patch(server)
+
+          Jekyll.logger.info "Server address:", server_address(server, opts)
+          launch_browser server, opts if opts["open_url"]
+          boot_or_detach server, opts
+        end
+
+        def jekyll_admin_monkey_patch(server)
           # Default Sinatra to "production" mode (surpress errors) unless
           # otherwise specified by the `RACK_ENV` environmental variable
           ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
 
           server.mount "/admin", Rack::Handler::WEBrick, Jekyll::Admin::StaticServer
           server.mount "/_api",  Rack::Handler::WEBrick, Jekyll::Admin::Server
-
-          Jekyll.logger.info "Server address:", server_address(server, opts)
-          launch_browser server, opts if opts["open_url"]
-          boot_or_detach server, opts
         end
       end
     end

--- a/script/test-server
+++ b/script/test-server
@@ -6,4 +6,4 @@ script/branding
 script/return-to-pwd
 
 cd ./spec/fixtures/site || exit
-bundle exec jekyll serve --verbose
+RACK_ENV=development bundle exec jekyll serve --verbose


### PR DESCRIPTION
@mertkahyaoglu this should set [these cross origin headers](https://github.com/britg/sinatra-cross_origin/blob/master/lib/sinatra/cross_origin.rb#L51-L57) in development, as well as properly respond to `OPTIONS` pre-flight checks. Does that look like it should work for testing between the two servers?

By default, JekyllAdmin will be in `production` mode (to prevent some strange cross-origin click jacking when running on a real site), but can be enabled by setting `RACK_ENV=development` (enabled by default for `script/test-server`).

Fixes https://github.com/jekyll/jekyll-admin/issues/29.