### PR TITLE
remove fixture gemfile

### DIFF
--- a/spec/fixtures/site/Gemfile
+++ b/spec/fixtures/site/Gemfile
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-path = File.expand_path "../../../", File.dirname(__FILE__)
-gem 'jekyll-admin', path: path


### PR DESCRIPTION
Over in https://github.com/jekyll/jekyll-admin/pull/31#issuecomment-231184838 @mertkahyaoglu said:

> One problem I encountered is that I got a dependency error saying `'cannot load such file -- sinatra/cross_origin'`. 
>I changed this line in `jekyll-admin.gemspec` file;
>
>`spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"` to this
>
> `spec.add_dependency "sinatra-cross_origin", "~> 0.3"` and it works without any error. Any suggestions?

The problem was that the root of the repo had a Gemfile, which had `jekyll-admin` as a development dependency (thus `sinatra-cross-origin` was loaded), but the `spec/fixture/site` folder, which `script/test-site` uses, had its own Gemfile, loading `jekyll-admin` as a runtime dependency, and thus it'd err out trying to find `sintra_cross-origin` which didn't exist in the bundle, since it was dev-only.

This PR simply removes the Gemfile, so bundler will use the Gemfile in the repo root (that has the cors library) to build the fixture site.

Tested `script/cibuild` and `script/test-server` and they both work with the change.