### PR TITLE
Properly respond to CORS preflight checks

### DIFF
--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -11,27 +11,17 @@ module Jekyll
         register Sinatra::CrossOrigin
         enable  :cross_origin
         disable :allow_credentials
+        set :allow_methods, %i(get options post put)
       end
-
-      ACCESS_CONTROL_ALLOW_HEADERS = %w(
-        X-Requested-With
-        X-HTTP-Method-Override
-        Content-Type
-        Cache-Control
-        Accept
-      ).freeze
 
       get "/" do
         json ROUTES.map { |route| ["#{route}_api", URI.join(base_url, "/_api/", route)] }.to_h
       end
 
-      # CORS preflight. See https://github.com/britg/sinatra-cross_origin#responding-to-options
+      # CORS preflight
       options "*" do
         render_404 unless settings.development?
-        response.headers["Allow"] = "HEAD,GET,PUT,POST,DELETE,OPTIONS"
-        response.headers["Access-Control-Allow-Headers"] = ACCESS_CONTROL_ALLOW_HEADERS.join(", ")
-
-        status 200
+        status 204
       end
 
       private

--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -11,7 +11,7 @@ module Jekyll
         register Sinatra::CrossOrigin
         enable  :cross_origin
         disable :allow_credentials
-        set :allow_methods, %i(get options post put)
+        set :allow_methods, %i(delete get options post put)
       end
 
       get "/" do

--- a/script/cibuild-ruby
+++ b/script/cibuild-ruby
@@ -7,5 +7,5 @@ if [ ! -d "./lib/jekyll/admin/public/dist" ]; then
 fi
 
 echo "Running Ruby tests..."
-bundle exec rspec
+RACK_ENV=development bundle exec rspec
 script/fmt

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -16,4 +16,18 @@ describe Jekyll::Admin::Server do
     expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar')
   end
+
+  it "responds to CORS preflight checks" do
+    options '/', {}, { "HTTP_ORIGIN" => "http://localhost:3000" }
+    expect(last_response.status).to eql(204)
+
+    expected = {
+      "Access-Control-Allow-Origin"  => "http://localhost:3000",
+      "Access-Control-Allow-Methods" => "GET, OPTIONS, POST, PUT"
+    }
+
+    expected.each do |key, value|
+      expect(last_response.headers[key]).to eql(value)
+    end
+  end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -23,7 +23,7 @@ describe Jekyll::Admin::Server do
 
     expected = {
       "Access-Control-Allow-Origin"  => "http://localhost:3000",
-      "Access-Control-Allow-Methods" => "GET, OPTIONS, POST, PUT"
+      "Access-Control-Allow-Methods" => "DELETE, GET, OPTIONS, POST, PUT"
     }
 
     expected.each do |key, value|


### PR DESCRIPTION
Per https://github.com/jekyll/jekyll-admin/pull/31#issuecomment-231464536

This removes the copy/paste CORS preflight implementation, and relies on the sinatra-cors native implementation to actually set the right headers, and to consistently respond with things like allowed methods.