### PR TITLE
Use sinatra-namespace to DRY things up a bit

### DIFF
--- a/lib/jekyll/admin.rb
+++ b/lib/jekyll/admin.rb
@@ -3,6 +3,8 @@ require "sinatra"
 require "sinatra/base"
 require "sinatra/json"
 require "sinatra/reloader"
+require "sinatra/namespace"
+
 require "json"
 require "jekyll"
 require "jekyll/admin/version"

--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -3,6 +3,8 @@ module Jekyll
     class Server < Sinatra::Base
       ROUTES = %w(collections configuration data pages static_files).freeze
 
+      register Sinatra::Namespace
+
       configure :development do
         register Sinatra::Reloader
         enable :logging

--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -1,63 +1,65 @@
 module Jekyll
   module Admin
     class Server < Sinatra::Base
-      get "/collections" do
-        json site.collections.map { |c| c[1].to_liquid }
-      end
+      namespace "/collections" do
+        get do
+          json site.collections.map { |c| c[1].to_liquid }
+        end
 
-      get "/collections/:collection_id" do
-        ensure_collection
-        json collection.to_liquid
-      end
+        get "/:collection_id" do
+          ensure_collection
+          json collection.to_liquid
+        end
 
-      get "/collections/:collection_id/documents" do
-        ensure_collection
-        json collection.docs.map(&:to_liquid)
-      end
+        get "/:collection_id/documents" do
+          ensure_collection
+          json collection.docs.map(&:to_liquid)
+        end
 
-      get "/collections/:collection_id/:document_id" do
-        ensure_document
-        content_type :json
-        document.to_liquid.to_json
-      end
+        get "/:collection_id/:document_id" do
+          ensure_document
+          content_type :json
+          document.to_liquid.to_json
+        end
 
-      put "/collections/:collection_id/:document_id" do
-        ensure_collection
-        File.write document_path, document_body
-        site.process
-        redirect to("/collections/#{collection.label}/#{params["document_id"]}")
-      end
+        put "/:collection_id/:document_id" do
+          ensure_collection
+          File.write document_path, document_body
+          site.process
+          redirect to("/collections/#{collection.label}/#{params["document_id"]}")
+        end
 
-      delete "/collections/:collection_id/:document_id" do
-        ensure_document
-        File.delete document_path
-        content_type :json
-        status 200
-        halt
-      end
+        delete "/:collection_id/:document_id" do
+          ensure_document
+          File.delete document_path
+          content_type :json
+          status 200
+          halt
+        end
 
-      private
+        private
 
-      def collection
-        collection = site.collections.find { |l, _c| l == params["collection_id"] }
-        collection[1] if collection
-      end
+        def collection
+          collection = site.collections.find { |l, _c| l == params["collection_id"] }
+          collection[1] if collection
+        end
 
-      def document_path
-        sanitized_path File.join(collection.directory, params["document_id"])
-      end
+        def document_path
+          sanitized_path File.join(collection.directory, params["document_id"])
+        end
 
-      def document
-        collection.docs.find { |d| d.path == document_path }
-      end
+        def document
+          collection.docs.find { |d| d.path == document_path }
+        end
 
-      def ensure_collection
-        render_404 if collection.nil?
-      end
+        def ensure_collection
+          render_404 if collection.nil?
+        end
 
-      def ensure_document
-        ensure_collection
-        render_404 if document.nil?
+        def ensure_document
+          ensure_collection
+          render_404 if document.nil?
+        end
       end
     end
   end

--- a/lib/jekyll/admin/server/configuration.rb
+++ b/lib/jekyll/admin/server/configuration.rb
@@ -1,25 +1,27 @@
 module Jekyll
   module Admin
     class Server < Sinatra::Base
-      get "/configuration" do
-        config = Jekyll::Configuration.new
-        config_files = config.config_files("source" => sanitized_path("/"))
-        json config.read_config_files(config_files).to_liquid
-      end
+      namespace "/configuration" do
+        get do
+          config = Jekyll::Configuration.new
+          config_files = config.config_files("source" => sanitized_path("/"))
+          json config.read_config_files(config_files).to_liquid
+        end
 
-      put "/configuration" do
-        File.write configuration_path, configuration_body
-        redirect to("/configuration")
-      end
+        put do
+          File.write configuration_path, configuration_body
+          redirect to("/configuration")
+        end
 
-      private
+        private
 
-      def configuration_body
-        YAML.dump request_payload
-      end
+        def configuration_body
+          YAML.dump request_payload
+        end
 
-      def configuration_path
-        sanitized_path "_config.yml"
+        def configuration_path
+          sanitized_path "_config.yml"
+        end
       end
     end
   end

--- a/lib/jekyll/admin/server/data.rb
+++ b/lib/jekyll/admin/server/data.rb
@@ -1,49 +1,51 @@
 module Jekyll
   module Admin
     class Server < Sinatra::Base
-      get "/data" do
-        json data_files.to_liquid
-      end
+      namespace "/data" do
+        get do
+          json data_files.to_liquid
+        end
 
-      get "/data/:data_file_id" do
-        ensure_data_file_exists
-        json data_file.to_liquid
-      end
+        get "/:data_file_id" do
+          ensure_data_file_exists
+          json data_file.to_liquid
+        end
 
-      put "/data/:data_file_id" do
-        File.write data_file_path, data_file_body
-        site.process
-        redirect to("/data/#{params["data_file_id"]}")
-      end
+        put "/:data_file_id" do
+          File.write data_file_path, data_file_body
+          site.process
+          redirect to("/data/#{params["data_file_id"]}")
+        end
 
-      delete "/data/:data_file_id" do
-        ensure_data_file_exists
-        File.delete data_file_path
-        content_type :json
-        status 200
-        halt
-      end
+        delete "/:data_file_id" do
+          ensure_data_file_exists
+          File.delete data_file_path
+          content_type :json
+          status 200
+          halt
+        end
 
-      private
+        private
 
-      def data_files
-        site.data
-      end
+        def data_files
+          site.data
+        end
 
-      def data_file
-        data_files[params["data_file_id"]]
-      end
+        def data_file
+          data_files[params["data_file_id"]]
+        end
 
-      def ensure_data_file_exists
-        render_404 if data_file.nil?
-      end
+        def ensure_data_file_exists
+          render_404 if data_file.nil?
+        end
 
-      def data_file_path
-        sanitized_path "_data/#{params["data_file_id"]}.yml"
-      end
+        def data_file_path
+          sanitized_path "_data/#{params["data_file_id"]}.yml"
+        end
 
-      def data_file_body
-        YAML.dump request_payload
+        def data_file_body
+          YAML.dump request_payload
+        end
       end
     end
   end

--- a/lib/jekyll/admin/server/page.rb
+++ b/lib/jekyll/admin/server/page.rb
@@ -1,41 +1,43 @@
 module Jekyll
   module Admin
     class Server < Sinatra::Base
-      get "/pages" do
-        json site.pages.map(&:to_liquid)
-      end
+      namespace "/pages" do
+        get do
+          json site.pages.map(&:to_liquid)
+        end
 
-      get "/pages/:page_id" do
-        ensure_page
-        json page.to_liquid
-      end
+        get "/:page_id" do
+          ensure_page
+          json page.to_liquid
+        end
 
-      put "/pages/:page_id" do
-        File.write page_path, page_body
-        site.process
-        redirect to("/pages/#{params["page_id"]}")
-      end
+        put "/:page_id" do
+          File.write page_path, page_body
+          site.process
+          redirect to("/pages/#{params["page_id"]}")
+        end
 
-      delete "/pages/:page_id" do
-        ensure_page
-        File.delete page_path
-        content_type :json
-        status 200
-        halt
-      end
+        delete "/:page_id" do
+          ensure_page
+          File.delete page_path
+          content_type :json
+          status 200
+          halt
+        end
 
-      private
+        private
 
-      def page_path
-        sanitized_path params["page_id"]
-      end
+        def page_path
+          sanitized_path params["page_id"]
+        end
 
-      def page
-        site.pages.find { |p| p.path == params["page_id"] }
-      end
+        def page
+          site.pages.find { |p| p.path == params["page_id"] }
+        end
 
-      def ensure_page
-        render_404 if page.nil?
+        def ensure_page
+          render_404 if page.nil?
+        end
       end
     end
   end

--- a/lib/jekyll/admin/server/static_file.rb
+++ b/lib/jekyll/admin/server/static_file.rb
@@ -1,49 +1,51 @@
 module Jekyll
   module Admin
     class Server < Sinatra::Base
-      get "/static_files" do
-        json static_files.map(&:to_liquid)
-      end
+      namespace "/static_files" do
+        get do
+          json static_files.map(&:to_liquid)
+        end
 
-      get "/static_files/:static_file_id" do
-        ensure_static_file_exists
-        redirect static_file.url
-      end
+        get "/:static_file_id" do
+          ensure_static_file_exists
+          redirect static_file.url
+        end
 
-      put "/static_files/:static_file_id" do
-        File.write static_file_path, static_file_body
-        site.process
-        redirect to("/static_files/#{params["static_file_id"]}")
-      end
+        put "/:static_file_id" do
+          File.write static_file_path, static_file_body
+          site.process
+          redirect to("/static_files/#{params["static_file_id"]}")
+        end
 
-      delete "/static_files/:static_file_id" do
-        ensure_static_file_exists
-        File.delete static_file_path
-        content_type :json
-        status 200
-        halt
-      end
+        delete "/:static_file_id" do
+          ensure_static_file_exists
+          File.delete static_file_path
+          content_type :json
+          status 200
+          halt
+        end
 
-      private
+        private
 
-      def static_file_path
-        sanitized_path params["static_file_id"]
-      end
+        def static_file_path
+          sanitized_path params["static_file_id"]
+        end
 
-      def static_file_body
-        request_payload["body"].to_s
-      end
+        def static_file_body
+          request_payload["body"].to_s
+        end
 
-      def static_files
-        site.static_files
-      end
+        def static_files
+          site.static_files
+        end
 
-      def static_file
-        static_files.find { |f| f.path == static_file_path }
-      end
+        def static_file
+          static_files.find { |f| f.path == static_file_path }
+        end
 
-      def ensure_static_file_exists
-        render_404 if static_file.nil?
+        def ensure_static_file_exists
+          render_404 if static_file.nil?
+        end
       end
     end
   end


### PR DESCRIPTION
I just discovered [Sinatra namespace](http://www.sinatrarb.com/contrib/namespace.html), which adds namespaces to Sinatra routes, and may help us DRY things up a bit.

In addition to removing the path prefix from each route, it also namespaces things like helpers and before filters.