### PR TITLE
Don't redirect CORS requests after write operations

### DIFF
--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -26,7 +26,8 @@ module Jekyll
           ensure_collection
           File.write document_path, document_body
           site.process
-          redirect to("/collections/#{collection.label}/#{params["document_id"]}")
+          content_type :json
+          document.to_liquid.to_json
         end
 
         delete "/:collection_id/:document_id" do

--- a/lib/jekyll/admin/server/configuration.rb
+++ b/lib/jekyll/admin/server/configuration.rb
@@ -3,17 +3,21 @@ module Jekyll
     class Server < Sinatra::Base
       namespace "/configuration" do
         get do
-          config = Jekyll::Configuration.new
-          config_files = config.config_files("source" => sanitized_path("/"))
-          json config.read_config_files(config_files).to_liquid
+          json configuration.to_liquid
         end
 
         put do
           File.write configuration_path, configuration_body
-          redirect to("/configuration")
+          json configuration.to_liquid
         end
 
         private
+
+        def configuration
+          config = Jekyll::Configuration.new
+          config_files = config.config_files("source" => sanitized_path("/"))
+          config.read_config_files(config_files)
+        end
 
         def configuration_body
           YAML.dump request_payload

--- a/lib/jekyll/admin/server/data.rb
+++ b/lib/jekyll/admin/server/data.rb
@@ -14,7 +14,7 @@ module Jekyll
         put "/:data_file_id" do
           File.write data_file_path, data_file_body
           site.process
-          redirect to("/data/#{params["data_file_id"]}")
+          json data_file.to_liquid
         end
 
         delete "/:data_file_id" do

--- a/lib/jekyll/admin/server/page.rb
+++ b/lib/jekyll/admin/server/page.rb
@@ -14,7 +14,7 @@ module Jekyll
         put "/:page_id" do
           File.write page_path, page_body
           site.process
-          redirect to("/pages/#{params["page_id"]}")
+          json page.to_liquid
         end
 
         delete "/:page_id" do

--- a/lib/jekyll/admin/server/static_file.rb
+++ b/lib/jekyll/admin/server/static_file.rb
@@ -14,7 +14,8 @@ module Jekyll
         put "/:static_file_id" do
           File.write static_file_path, static_file_body
           site.process
-          redirect to("/static_files/#{params["static_file_id"]}")
+          status 200
+          halt
         end
 
         delete "/:static_file_id" do

--- a/lib/jekyll/admin/server/static_file.rb
+++ b/lib/jekyll/admin/server/static_file.rb
@@ -8,14 +8,13 @@ module Jekyll
 
         get "/:static_file_id" do
           ensure_static_file_exists
-          redirect static_file.url
+          json static_file.to_liquid
         end
 
         put "/:static_file_id" do
           File.write static_file_path, static_file_body
           site.process
-          status 200
-          halt
+          json static_file.to_liquid
         end
 
         delete "/:static_file_id" do

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -54,9 +54,7 @@ describe "collections" do
     }
     put '/collections/posts/2016-01-01-test2.md', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/collections/posts/2016-01-01-test2.md')
+    expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar')
     File.delete(path)
   end
@@ -67,15 +65,13 @@ describe "collections" do
     File.write path, "---\n---\n\ntest"
 
     request = {
-      :meta => { :foo => "bar" },
+      :meta => { :foo => "bar2" },
       :body => "test"
     }
     put '/collections/posts/2016-01-01-test2.md', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/collections/posts/2016-01-01-test2.md')
-    expect(last_response_parsed["foo"]).to eq('bar')
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar2')
     File.delete(path)
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,13 +13,18 @@ describe "configuration" do
   end
 
   it "updates the configuration" do
-    config_path = File.expand_path "_config.yml", fixture_path("site")
-    config = YAML.load_file(config_path)
+    config_path   = File.expand_path "_config.yml", fixture_path("site")
+    config_body   = File.read(config_path)
+    config_before = YAML.load(config_body)
+    config = config_before.dup
+
+    config["foo"] = "bar2"
     put "/configuration", config.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/configuration')
-    expect(last_response_parsed["foo"]).to eql("bar")
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eql("bar2")
+    expect(last_response_parsed.key?("source")).to eql(false)
+
+    File.write(config_path, config_body)
   end
 end

--- a/spec/data_file_spec.rb
+++ b/spec/data_file_spec.rb
@@ -24,10 +24,8 @@ describe "data" do
     request = { "foo" => "bar" }
     put '/data/data-file-new', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/data/data-file-new')
-    expect(last_response_parsed["foo"]).to eq('bar')
+    expect(last_response).to be_ok
+    expect(last_response_parsed).to eql({ "foo" => "bar" })
     File.delete(path)
   end
 
@@ -36,13 +34,11 @@ describe "data" do
     File.delete(path) if File.exist?(path)
     File.write path, "foo2: bar2"
 
-    request = { "foo" => "bar" }
+    request = { "foo" => "bar2" }
     put '/data/data-file-update', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/data/data-file-update')
-    expect(last_response_parsed["foo"]).to eq('bar')
+    expect(last_response).to be_ok
+    expect(last_response_parsed).to eql({ "foo" => "bar2" })
     File.delete(path)
   end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -40,10 +40,9 @@ describe "pages" do
     }
     put '/pages/page-new.md', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/pages/page-new.md')
+    expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar')
+
     File.delete(path)
   end
 
@@ -53,15 +52,14 @@ describe "pages" do
     File.write path, "---\n---\n\ntest"
 
     request = {
-      :meta => { :foo => "bar" },
+      :meta => { :foo => "bar2" },
       :body => "test"
     }
     put '/pages/page-update.md', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/pages/page-update.md')
-    expect(last_response_parsed["foo"]).to eq('bar')
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar2')
+
     File.delete(path)
   end
 

--- a/spec/static_file_spec.rb
+++ b/spec/static_file_spec.rb
@@ -11,11 +11,11 @@ describe "static_files" do
     expect(last_response_parsed.last["path"]).to eql("/static-file.txt")
   end
 
-  it "redirects to the real file" do
+  it "returns a single static file" do
     get "/static_files/static-file.txt"
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/static-file.txt')
+    expect(last_response).to be_ok
+    expect(last_response_parsed["extname"]).to eql(".txt")
+    expect(last_response_parsed["path"]).to eql("/static-file.txt")
   end
 
   it "404s when a static file doesn't exist" do
@@ -31,6 +31,9 @@ describe "static_files" do
     put '/static_files/static-file-new.txt', request.to_json
 
     expect(last_response).to be_ok
+    expect(last_response_parsed["extname"]).to eql(".txt")
+    expect(last_response_parsed["path"]).to eql("/static-file-new.txt")
+
     File.delete(path)
   end
 
@@ -43,6 +46,9 @@ describe "static_files" do
     put '/static_files/static-file-update.txt', request.to_json
 
     expect(last_response).to be_ok
+    expect(last_response_parsed["extname"]).to eql(".txt")
+    expect(last_response_parsed["path"]).to eql("/static-file-update.txt")
+
     File.delete(path)
   end
 

--- a/spec/static_file_spec.rb
+++ b/spec/static_file_spec.rb
@@ -30,9 +30,7 @@ describe "static_files" do
     request = { :body => "test" }
     put '/static_files/static-file-new.txt', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/static_files/static-file-new.txt')
+    expect(last_response).to be_ok
     File.delete(path)
   end
 
@@ -44,9 +42,7 @@ describe "static_files" do
     request = { :body => "test" }
     put '/static_files/static-file-update.txt', request.to_json
 
-    expect(last_response).to be_redirect
-    follow_redirect!
-    expect(last_request.url).to eql('http://example.org/static_files/static-file-update.txt')
+    expect(last_response).to be_ok
     File.delete(path)
   end
 


### PR DESCRIPTION
Per https://github.com/jekyll/jekyll-admin/pull/31#issuecomment-231491593, CORS requests can't result in a `30x` redirect.

This PR updates the logic such that any `PUT` or `POST` operation returns the resulting object, rather than a 301 to the corresponding `GET` endpoint.

Likewise, under the same rationale, the `GET` operation for static files, now returns the static file object, rather than a blind 301 to the real path (but the object contains the real path, so behavior can be preserved).

