### PR TITLE
Add development and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jekyll/jekyll-admin.svg?branch=master)](https://travis-ci.org/jekyll/jekyll-admin)
 
-Jekyll::Admin is a drop in administrative framework for Jekyll.
+A Jekyll plugin that provides users with a traditional CMS-style graphical interface to author content and administer Jekyll sites. The project is divided into two parts. A Ruby-based HTTP API that handles Jekyll and filesystem operations, and a Javascript-based front end, built on that API.
 
 ## Installation
 
@@ -12,29 +12,13 @@ Refer to [Install Plugins](https://jekyllrb.com/docs/plugins/#installing-a-plugi
 
 Upon successful installation, you should be able to access the admin panel at `/admin` and the api at `/_api` respectively.
 
-## Development
-
-### To install locally
-
-`script/bootstrap`
-
-### Running tests
-
-`script/cibuild`
-
-### Running a test server with a dummy site
-
-`script/test-server`
-
-### The environment flag
-
-When developing locally, it can be helpful to see error backtraces, disable template caching, have expanded request logs, and to allow cross-origin requests between the Ruby server and the Node server. By default, however, JekyllAdmin runs in `production` mode, meaning these development features are disabled.
-
-To enabled the development features, set the environmental variable `RACK_ENV` to `development`. When enabled, the `/_api/` endpoint will add `Access-Control-Allow-Origin: any` headers, and respond to `OPTIONS` pre-flight checks. This flag is set automatically when using the `script/test-server` command.
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll/jekyll-admin. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+## Development
+
+See [the development docs](/docs/development.md)
 
 ## License
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,138 @@
+## HTTP API
+
+The below are the documented endpoints of the shared HTTP API. All requests and responses are made in JSON, and should follow RESTful standards, including respecting HTTP verbs.
+
+For simplicity, whenever possible, the API mirrors Jekyll internal data structures, meaning, objects are generally the results of calling `.to_liquid.to_json` on an existing Jekyll model (and the resulting fields).
+
+### Collections
+#### Parameters
+
+* `collection_name` - the name of the collection, e.g., posts (`String`)
+* `id` - the filename of a document, relative to the collection root (e.g., `2016-01-01-some-post.md` or `rover.md`) (`String`)
+* `body` - the document body (`String`)
+* `meta` - the document's YAML front matter (`Object`)
+
+#### `GET /collections/`
+
+Returns an array of the registered collections.
+
+#### `GET /collections/:collection_name`
+
+Returns information about the requested collection
+
+#### `GET /collections/:collection_name/documents`
+
+Return an array of document objects corresponding to the requested collection. The response does not include the document body.
+
+#### `GET /collections/:collection_name/:id`
+
+Returns the requested document. The response includes the document body.
+
+#### `PUT /collections/:collection_name/:id`
+
+Create or update the requested document, writing its contents to disk.
+
+#### `DELETE /collections/:collection_name/:id`
+
+Delete the requested document from disk.
+
+### Pages
+
+#### Parameters
+
+* `id` - The file's path, relative to the site root (e.g., `about.html`) (`String`)
+* `body` - the page's body (`String`)
+* `meta` - the page's YAML front matter (`Object`)
+
+#### `GET /pages`
+
+Return an array of page objects. The response does not include the page body.
+
+#### `GET /pages/:id`
+
+Returns the requested page. The response includes the page body.
+
+#### `PUT /pages/:id`
+
+Create or update the requested page, writing its contents to disk.
+
+#### `DELETE /pages/:id`
+
+Delete the requested page from disk.
+
+### Configuration
+
+#### `GET /configuration`
+
+Returns the parsed site configuration.
+
+#### `PUT /configuration`
+
+Create or update the site's `_config.yml` file with the requested contents.
+
+File will be written to disk in YAML. It will not necessarily to preserve whitespace or in-line comments.
+
+### Static files
+
+* `path` - the path to the file or directory, relative to the site root (`String`)
+
+### `GET /static_files/:path`
+
+Returns the requested static file. The response does not include the file's content.
+
+If the path maps to a directory, it list all static files in the directory. This does not include documents, pages, etc.
+
+### `PUT /static_files/:path`
+
+Create or update a static file on disk. This can be arbitrary ASCII or a binary file (e.g., an image).
+
+### `DELETE /static_files/:path`
+
+Delete a static file from disk.
+
+### Data files
+
+### Parameters
+
+* `data_file` - File path relative to the `_data` folder without an extension. (`String`)
+
+#### `GET /data`
+
+Returns an array of data files. Does not include the file contents.
+
+#### `GET /data/:data_file`
+
+Returns the requested, parsed data file.
+
+#### `PUT /data/:data_file`
+
+Create or update the requested data file with the requested contents.
+
+File will be written to disk in YAML. It will necessarily preserve whitespace or in-line comments.
+
+#### `DELETE /data/:data_file`
+
+Remove the requested data file from disk.
+
+### Git operations
+
+### Parameters
+
+* `remote` - the git remote to act against, defaults to `origin` (`String`)
+* `branch` - the branch to act against, defaults to `master` (`String`)
+
+### `GET /git/status`
+
+Returns information about the current working tree.
+
+### `GET /git/pull`
+
+Pull changes from the remote and branch.
+
+### `PUT /git/commit`
+
+Commit the local changes.
+
+### `POST /git/push`
+
+Push changes to the remote and branch.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,19 @@
+## Development
+
+### To install locally
+
+`script/bootstrap`
+
+### Running tests
+
+`script/cibuild`
+
+### Running a test server with a dummy site
+
+`script/test-server`
+
+### The environment flag
+
+When developing locally, it can be helpful to see error backtraces, disable template caching, have expanded request logs, and to allow cross-origin requests between the Ruby server and the Node server. By default, however, JekyllAdmin runs in `production` mode, meaning these development features are disabled.
+
+To enabled the development features, set the environmental variable `RACK_ENV` to `development`. When enabled, the `/_api/` endpoint will add `Access-Control-Allow-Origin: any` headers, and respond to `OPTIONS` pre-flight checks. This flag is set automatically when using the `script/test-server` command.


### PR DESCRIPTION
This pull request creates a `/docs` folder, and publishes the API specification that we were previously collaborating on in a private repository. 

I also took the opportunity to move some of the existing development docs out of the readme and into their own `/docs/development.md` file.

Fixes https://github.com/jekyll/jekyll-admin/issues/38.
