### PR TITLE
Return pages and documents without frontmatter defaults

### DIFF
--- a/lib/jekyll/admin.rb
+++ b/lib/jekyll/admin.rb
@@ -16,6 +16,7 @@ require "jekyll/admin/server/data.rb"
 require "jekyll/admin/server/page.rb"
 require "jekyll/admin/server/static_file.rb"
 require_relative "./commands/serve"
+require_relative "./convertible_ext"
 
 module Jekyll
   module Admin

--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -19,7 +19,7 @@ module Jekyll
         get "/:collection_id/:document_id" do
           ensure_document
           content_type :json
-          document.to_liquid.to_json
+          document_without_frontmatter_defaults.to_liquid.to_json
         end
 
         put "/:collection_id/:document_id" do
@@ -27,7 +27,7 @@ module Jekyll
           File.write document_path, document_body
           site.process
           content_type :json
-          document.to_liquid.to_json
+          document_without_frontmatter_defaults.to_liquid.to_json
         end
 
         delete "/:collection_id/:document_id" do
@@ -60,6 +60,19 @@ module Jekyll
         def ensure_document
           ensure_collection
           render_404 if document.nil?
+        end
+
+        def document_without_frontmatter_defaults(opts = {})
+          doc = document.dup
+          contents = File.read(document.path, Utils.merged_file_read_opts(site, opts))
+
+          if contents =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+            doc.instance_variable_set "@data", SafeYAML.load(Regexp.last_match(1))
+          else
+            doc.data = {}
+          end
+
+          doc
         end
       end
     end

--- a/lib/jekyll/admin/server/page.rb
+++ b/lib/jekyll/admin/server/page.rb
@@ -3,18 +3,18 @@ module Jekyll
     class Server < Sinatra::Base
       namespace "/pages" do
         get do
-          json site.pages.map(&:to_liquid)
+          json site.pages.map(&:to_liquid_without_frontmatter_defaults)
         end
 
         get "/:page_id" do
           ensure_page
-          json page.to_liquid
+          json page.to_liquid_without_frontmatter_defaults
         end
 
         put "/:page_id" do
           File.write page_path, page_body
           site.process
-          json page.to_liquid
+          json page.to_liquid_without_frontmatter_defaults
         end
 
         delete "/:page_id" do

--- a/lib/jekyll/convertible_ext.rb
+++ b/lib/jekyll/convertible_ext.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  module Convertible
+    # Modified version of https://github.com/jekyll/jekyll/blob/master/lib/jekyll/convertible.rb#L131-L141
+    def to_liquid_without_frontmatter_defaults(attrs = nil)
+      further_data = Hash[(attrs || self.class::ATTRIBUTES_FOR_LIQUID).map do |attribute|
+        [attribute, send(attribute)]
+      end]
+
+      Utils.deep_merge_hashes(data, further_data)
+    end
+  end
+end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -34,6 +34,11 @@ describe "collections" do
     expect(last_response_parsed["title"]).to eq('Test')
   end
 
+  it "doesn't contain front matter defaults" do
+    get '/collections/posts/2016-01-01-test.md'
+    expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+  end
+
   it "404s for an unknown document" do
     get '/collections/posts/foo'
     expect(last_response.status).to eql(404)

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -6,3 +6,10 @@ exclude:
 - Gemfile.lock
 - README.md
 foo: bar
+
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      some_front_matter: "default"

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -25,6 +25,11 @@ describe "pages" do
     expect(last_response_parsed["foo"]).to eq('bar')
   end
 
+  it "doesn't contain front matter defaults" do
+    get "/pages/page.md"
+    expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+  end
+
   it "404s for an unknown page" do
     get "/pages/foo.md"
     expect(last_response.status).to eql(404)


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-admin/issues/30.

@parkr (or maybe @pathawks) before I go down the path of adding tests, I could use your 💭...

We want to be able to return pages and documents without their front matter defaults.

For Pages, that's a matter of making a new `to_liquid` method, that doesn't merge in front matter defaults, as the defaults are not merged in until `to_liquid` is called.

For Documents, that's a matter of re-reading the file, duplicating the object, and manually swapping in the data before calling `to_liquid`, because front matter defaults are injected on load.

Specific questions:

1. Is this the right approach? Is there a better one?
2. is their a ruby file naming convention for monkey patching?


