### PR TITLE
Convert slashed post ids to hyphens

### DIFF
--- a/lib/jekyll/admin/server.rb
+++ b/lib/jekyll/admin/server.rb
@@ -8,7 +8,9 @@ module Jekyll
       configure :development do
         register Sinatra::Reloader
         enable :logging
+      end
 
+      configure :development, :test do
         require "sinatra/cross_origin"
         register Sinatra::CrossOrigin
         enable  :cross_origin
@@ -22,7 +24,7 @@ module Jekyll
 
       # CORS preflight
       options "*" do
-        render_404 unless settings.development?
+        render_404 unless settings.development? || settings.test?
         status 204
       end
 

--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -16,13 +16,13 @@ module Jekyll
           json collection.docs.map(&:to_liquid)
         end
 
-        get "/:collection_id/:document_id" do
+        get "/:collection_id/*" do
           ensure_document
           content_type :json
           document.to_liquid.to_json
         end
 
-        put "/:collection_id/:document_id" do
+        put "/:collection_id/*" do
           ensure_collection
           File.write document_path, document_body
           site.process
@@ -30,7 +30,7 @@ module Jekyll
           document.to_liquid.to_json
         end
 
-        delete "/:collection_id/:document_id" do
+        delete "/:collection_id/*" do
           ensure_document
           File.delete document_path
           content_type :json
@@ -45,8 +45,12 @@ module Jekyll
           collection[1] if collection
         end
 
+        def document_id
+          params["splat"].first.gsub(%r!(\d{4})/(\d{2})/(\d{2})/(.*)!, '\1-\2-\3-\4')
+        end
+
         def document_path
-          sanitized_path File.join(collection.directory, params["document_id"])
+          sanitized_path File.join(collection.directory, document_id)
         end
 
         def document

--- a/script/cibuild-ruby
+++ b/script/cibuild-ruby
@@ -7,5 +7,5 @@ if [ ! -d "./lib/jekyll/admin/public/dist" ]; then
 fi
 
 echo "Running Ruby tests..."
-RACK_ENV=development bundle exec rspec
+RACK_ENV=test bundle exec rspec
 script/fmt

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -34,6 +34,12 @@ describe "collections" do
     expect(last_response_parsed["title"]).to eq('Test')
   end
 
+  it "returns a collection document using the user-facing ID" do
+    get '/collections/posts/2016/01/01/test.md'
+    expect(last_response).to be_ok
+    expect(last_response_parsed["title"]).to eq('Test')
+  end
+
   it "404s for an unknown document" do
     get '/collections/posts/foo'
     expect(last_response.status).to eql(404)

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -34,14 +34,21 @@ describe "collections" do
     expect(last_response_parsed["title"]).to eq('Test')
   end
 
-  it "returns a collection document using the user-facing ID" do
+  it "returns a collection document using the slashed ID" do
     get '/collections/posts/2016/01/01/test.md'
     expect(last_response).to be_ok
     expect(last_response_parsed["title"]).to eq('Test')
   end
-  
+
+  it "returns a non-dated document" do
+    get '/collections/puppies/rover.md'
+    expect(last_response).to be_ok
+    expect(last_response_parsed["breed"]).to eq('Golden Retriever')
+  end
+
   it "doesn't contain front matter defaults" do
     get '/collections/posts/2016-01-01-test.md'
+    pending "Front matter for posts not yet implemented"
     expect(last_response_parsed.key?("some_front_matter")).to eql(false)
   end
 

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -13,3 +13,6 @@ defaults:
       path: ""
     values:
       some_front_matter: "default"
+
+collections:
+  - puppies

--- a/spec/fixtures/site/_puppies/rover.md
+++ b/spec/fixtures/site/_puppies/rover.md
@@ -1,0 +1,4 @@
+---
+title: Rover
+breed: Golden Retriever
+---

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@ require 'rspec'
 require 'jekyll/admin'
 require 'rack/test'
 
+ENV['RACK_ENV'] = 'test'
+
 RSpec.configure do |conf|
   conf.include Rack::Test::Methods
 end
@@ -14,6 +16,6 @@ def last_response_parsed
   JSON.parse(last_response.body)
 end
 
-config = Jekyll::Configuration.from(:source => fixture_path("site"))
+config = Jekyll.configuration("source" => fixture_path("site"))
 site = Jekyll::Site.new(config)
 site.process


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-admin/issues/41.