### PR TITLE
Properly return documents without frontmatter

### DIFF
--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -48,7 +48,6 @@ describe "collections" do
 
   it "doesn't contain front matter defaults" do
     get '/collections/posts/2016-01-01-test.md'
-    pending "Front matter for posts not yet implemented"
     expect(last_response_parsed.key?("some_front_matter")).to eql(false)
   end
 


### PR DESCRIPTION
A follow up to https://github.com/jekyll/jekyll-admin/pull/43 which really fixes #30, this ensures that documents do not have front matter defaults set when returned.