### PR TITLE
Return raw Jekyll config as it appears on disk, not the computed config

### DIFF
--- a/lib/jekyll/admin/server/configuration.rb
+++ b/lib/jekyll/admin/server/configuration.rb
@@ -3,28 +3,40 @@ module Jekyll
     class Server < Sinatra::Base
       namespace "/configuration" do
         get do
-          json configuration.to_liquid
+          json raw_configuration.to_liquid
         end
 
         put do
           File.write configuration_path, configuration_body
-          json configuration.to_liquid
+          json raw_configuration.to_liquid
         end
 
         private
 
-        def configuration
-          config = Jekyll::Configuration.new
-          config_files = config.config_files("source" => sanitized_path("/"))
-          config.read_config_files(config_files)
+        def overrides
+          {
+            "source" => sanitized_path("/")
+          }
         end
 
+        # Computed configuration, with updates and defaults
+        def configuration
+          @configuration ||= Jekyll.configuration(overrides)
+        end
+
+        # Raw configuration, as it sits on disk
+        def raw_configuration
+          configuration.read_config_file(configuration_path)
+        end
+
+        # Returns the path to the *first* config file discovered
+        def configuration_path
+          sanitized_path configuration.config_files(overrides).first
+        end
+
+        # The user's uploaded configuration for updates
         def configuration_body
           YAML.dump request_payload
-        end
-
-        def configuration_path
-          sanitized_path "_config.yml"
         end
       end
     end

--- a/script/cibuild-ruby
+++ b/script/cibuild-ruby
@@ -7,5 +7,5 @@ if [ ! -d "./lib/jekyll/admin/public/dist" ]; then
 fi
 
 echo "Running Ruby tests..."
-RACK_ENV=test bundle exec rspec
+RACK_ENV=test JEKYLL_LOG_LEVEL=warn bundle exec rspec
 script/fmt

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -19,12 +19,32 @@ describe "configuration" do
     config = config_before.dup
 
     config["foo"] = "bar2"
-    put "/configuration", config.to_json
+    begin
+      put "/configuration", config.to_json
 
-    expect(last_response).to be_ok
-    expect(last_response_parsed["foo"]).to eql("bar2")
-    expect(last_response_parsed.key?("source")).to eql(false)
+      expect(last_response).to be_ok
+      expect(last_response_parsed["foo"]).to eql("bar2")
+      expect(last_response_parsed.key?("source")).to eql(false)
+    ensure
+      File.write(config_path, config_body)
+    end
+  end
 
-    File.write(config_path, config_body)
+  it "doesn't inject the default collections" do
+    config_path   = File.expand_path "_config.yml", fixture_path("site")
+    config_body   = File.read(config_path)
+    config_before = YAML.load(config_body)
+
+    config = config_before.dup
+    config["collections"]["test"] = { "foo" => "bar" }
+
+    begin
+      put "/configuration", config.to_json
+      collections = last_response_parsed["collections"]
+      expect(collections["test"]["foo"]).to eql("bar")
+      expect(collections.key?("posts")).to eql(false)
+    ensure
+      File.write(config_path, config_body)
+    end
   end
 end

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -16,4 +16,6 @@ defaults:
       some_front_matter: "default"
 
 collections:
-  - puppies
+  puppies:
+    foo: bar
+    output: true


### PR DESCRIPTION
This pull request updates how the config is displayed, preferring the version that's on disk, using Jekyll's existing reading logic, rather than the computed config, which upgrades deprecated keys, injects defaults, etc. 

This approach essentially duplicated `read_config_files`, but we're only looking at the first config file for now, because the spec assumes a single config file.

Fixes https://github.com/jekyll/jekyll-admin/issues/44