### PR TITLE
Return raw, unrendered markdown via API

### DIFF
--- a/lib/jekyll/convertible_ext.rb
+++ b/lib/jekyll/convertible_ext.rb
@@ -6,6 +6,11 @@ module Jekyll
         [attribute, send(attribute)]
       end]
 
+      path = File.join(@base, @dir, name)
+      content = File.read(path, Utils.merged_file_read_opts(site, {}))
+      content = $POSTMATCH if content =~ Document::YAML_FRONT_MATTER_REGEXP
+      further_data["raw_content"] = content
+
       Utils.deep_merge_hashes(data, further_data)
     end
   end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -5,6 +5,14 @@ describe "collections" do
     Jekyll::Admin::Server
   end
 
+  before(:each) do
+    Jekyll::Admin.site.process
+  end
+
+  after(:each) do
+    Jekyll::Admin.site.process
+  end
+
   it "returns the collection index" do
     get '/collections'
     expect(last_response).to be_ok
@@ -17,12 +25,18 @@ describe "collections" do
     expect(last_response_parsed["label"]).to eq('posts')
   end
 
-  it "returns collection documents" do
-    get '/collections/posts/documents'
-    expect(last_response).to be_ok
-    first_document = last_response_parsed.first
-    expect(first_document["title"]).to eq('Test')
-    expect(first_document.key?("some_front_matter")).to eq(false)
+  context "document index" do
+    it "returns collection documents" do
+      get '/collections/posts/documents'
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first["title"]).to eq('Test')
+    end
+
+    it "doesn't include front matter defaults" do
+      get '/collections/posts/documents'
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first.key?("some_front_matter")).to eq(false)
+    end
   end
 
   it "404s for an unknown collection" do
@@ -30,37 +44,52 @@ describe "collections" do
     expect(last_response.status).to eql(404)
   end
 
-  it "returns a collection document" do
-    get '/collections/posts/2016-01-01-test.md'
-    expect(last_response).to be_ok
-    expect(last_response_parsed["title"]).to eq('Test')
-  end
+  context "gettting a single document" do
+    it "returns a collection document" do
+      get '/collections/posts/2016-01-01-test.md'
+      expect(last_response).to be_ok
+      expect(last_response_parsed["title"]).to eq('Test')
+    end
 
-  it "returns a collection document using the slashed ID" do
-    get '/collections/posts/2016/01/01/test.md'
-    expect(last_response).to be_ok
-    expect(last_response_parsed["title"]).to eq('Test')
-  end
+    it "returns a collection document using the slashed ID" do
+      get '/collections/posts/2016/01/01/test.md'
+      expect(last_response).to be_ok
+      expect(last_response_parsed["title"]).to eq('Test')
+    end
 
-  it "returns a non-dated document" do
-    get '/collections/puppies/rover.md'
-    expect(last_response).to be_ok
-    expect(last_response_parsed["breed"]).to eq('Golden Retriever')
-  end
+    it "returns a non-dated document" do
+      get '/collections/puppies/rover.md'
+      expect(last_response).to be_ok
+      expect(last_response_parsed["breed"]).to eq('Golden Retriever')
+    end
 
-  it "doesn't contain front matter defaults" do
-    get '/collections/posts/2016-01-01-test.md'
-    expect(last_response_parsed.key?("some_front_matter")).to eql(false)
-  end
+    it "returns the rendered output" do
+      get '/collections/posts/2016-01-01-test.md'
+      expect(last_response).to be_ok
+      expected = "<h1 id=\"test-post\">Test Post</h1>\n"
+      expect(last_response_parsed["output"]).to eq(expected)
+    end
 
-  it "404s for an unknown document" do
-    get '/collections/posts/foo'
-    expect(last_response.status).to eql(404)
-  end
+    it "returns the raw content" do
+      get '/collections/posts/2016-01-01-test.md'
+      expect(last_response).to be_ok
+      expect(last_response_parsed["raw_content"]).to eq("# Test Post\n")
+    end
 
-  it "404s for an unknown collection and document" do
-    get '/collections/foo/bar'
-    expect(last_response.status).to eql(404)
+    it "doesn't contain front matter defaults" do
+      get '/collections/posts/2016-01-01-test.md'
+      expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+    end
+
+    it "404s for an unknown document" do
+      get '/collections/posts/foo'
+      expect(last_response.status).to eql(404)
+    end
+
+    it "404s for an unknown collection and document" do
+      get '/collections/foo/bar'
+      expect(last_response.status).to eql(404)
+    end
   end
 
   it "writes a new file" do
@@ -98,6 +127,7 @@ describe "collections" do
     path = File.expand_path "_posts/2016-01-01-test2.md", fixture_path("site")
     File.delete(path) if File.exist?(path)
     File.write path, "---\n---\n\ntest"
+    Jekyll::Admin.site.process
     delete '/collections/posts/2016-01-01-test2.md'
     expect(last_response).to be_ok
     expect(File.exist?(path)).to eql(false)

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -13,26 +13,49 @@ describe "pages" do
     Jekyll::Admin.site.process
   end
 
-  it "lists pages" do
-    get "/pages"
-    expect(last_response).to be_ok
-    expect(last_response_parsed.last["name"]).to eq('page.md')
+  context "page index" do
+    it "lists pages" do
+      get "/pages"
+      expect(last_response).to be_ok
+      expect(last_response_parsed.last["name"]).to eq('page.md')
+    end
+
+    it "doesn't include front matter defaults" do
+      get "/pages"
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first.key?("some_front_matter")).to eq(false)
+    end
   end
 
-  it "returns a page" do
-    get "/pages/page.md"
-    expect(last_response).to be_ok
-    expect(last_response_parsed["foo"]).to eq('bar')
-  end
+  context "getting a single page" do
+    it "returns a page" do
+      get "/pages/page.md"
+      expect(last_response).to be_ok
+      expect(last_response_parsed["foo"]).to eq('bar')
+    end
 
-  it "doesn't contain front matter defaults" do
-    get "/pages/page.md"
-    expect(last_response_parsed.key?("some_front_matter")).to eql(false)
-  end
+    it "returns the rendered output" do
+      get "/pages/page.md"
+      expect(last_response).to be_ok
+      expected = "<h1 id=\"test-page\">Test Page</h1>\n"
+      expect(last_response_parsed["content"]).to eq(expected)
+    end
 
-  it "404s for an unknown page" do
-    get "/pages/foo.md"
-    expect(last_response.status).to eql(404)
+    it "returns the raw content" do
+      get "/pages/page.md"
+      expect(last_response).to be_ok
+      expect(last_response_parsed["raw_content"]).to eq("# Test Page\n")
+    end
+
+    it "doesn't contain front matter defaults" do
+      get "/pages/page.md"
+      expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+    end
+
+    it "404s for an unknown page" do
+      get "/pages/foo.md"
+      expect(last_response.status).to eql(404)
+    end
   end
 
   it "writes a new page" do


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-admin/issues/35.

My proposed solution here is to add a `raw_content` filed, which will contain the unrendered markdown.

@parkr thoughts?