### PR TITLE
Allow pages and collection endpoints to rename files

### DIFF
--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -24,6 +24,13 @@ module Jekyll
 
         put "/:collection_id/*" do
           ensure_collection
+
+          # Rename page
+          if request_payload["path"] && request_payload["path"] != params["splat"].first
+            File.delete document_path
+            params["splat"] = [request_payload["path"]]
+          end
+
           File.write document_path, document_body
           site.process
           content_type :json

--- a/lib/jekyll/admin/server/page.rb
+++ b/lib/jekyll/admin/server/page.rb
@@ -12,6 +12,12 @@ module Jekyll
         end
 
         put "/:page_id" do
+          # Rename page
+          if request_payload["path"] && request_payload["path"] != params["page_id"]
+            File.delete page_path
+            params["page_id"] = request_payload["path"]
+          end
+
           File.write page_path, page_body
           site.process
           json page.to_liquid_without_frontmatter_defaults

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -93,8 +93,7 @@ describe "collections" do
   end
 
   it "writes a new file" do
-    path = File.expand_path "_posts/2016-01-01-test2.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
+    delete_file "_posts/2016-01-01-test2.md"
 
     request = {
       :meta => { :foo => "bar" },
@@ -104,13 +103,12 @@ describe "collections" do
 
     expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar')
-    File.delete(path)
+
+    delete_file "_posts/2016-01-01-test2.md"
   end
 
   it "updates a file" do
-    path = File.expand_path "_posts/2016-01-01-test2.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "---\n---\n\ntest"
+    write_file "_posts/2016-01-01-test2.md"
 
     request = {
       :meta => { :foo => "bar2" },
@@ -120,14 +118,33 @@ describe "collections" do
 
     expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar2')
-    File.delete(path)
+
+    delete_file "_posts/2016-01-01-test2.md"
+  end
+
+  it "renames a file" do
+    write_file "_posts/2016-01-01-test2.md"
+    delete_file "_posts/2016-01-02-test2.md"
+
+    request = {
+      :path => "2016-01-02-test2.md",
+      :meta => { :foo => "bar2" },
+      :body => "test"
+    }
+
+    put '/collections/posts/2016-01-01-test2.md', request.to_json
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar2')
+
+    get '/collections/posts/2016-01-02-test2.md', request.to_json
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar2')
+
+    delete_file "_posts/2016-01-01-test2.md", "_posts/2016-01-02-test2.md"
   end
 
   it "deletes a file" do
-    path = File.expand_path "_posts/2016-01-01-test2.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "---\n---\n\ntest"
-    Jekyll::Admin.site.process
+    path = write_file "_posts/2016-01-01-test2.md"
     delete '/collections/posts/2016-01-01-test2.md'
     expect(last_response).to be_ok
     expect(File.exist?(path)).to eql(false)

--- a/spec/data_file_spec.rb
+++ b/spec/data_file_spec.rb
@@ -18,37 +18,32 @@ describe "data" do
   end
 
   it "writes a new data file" do
-    path = File.expand_path "_data/data-file-new.yml", fixture_path("site")
-    File.delete(path) if File.exist?(path)
+    delete_file "_data/data-file-new.yml"
 
     request = { "foo" => "bar" }
     put '/data/data-file-new', request.to_json
 
     expect(last_response).to be_ok
     expect(last_response_parsed).to eql({ "foo" => "bar" })
-    File.delete(path)
+
+    delete_file "_data/data-file-new.yml"
   end
 
   it "updates a data file" do
-    path = File.expand_path "_data/data-file-update.yml", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "foo2: bar2"
+    write_file "_data/data-file-update.yml", "foo2: bar2"
 
     request = { "foo" => "bar2" }
     put '/data/data-file-update', request.to_json
 
     expect(last_response).to be_ok
     expect(last_response_parsed).to eql({ "foo" => "bar2" })
-    File.delete(path)
+
+    delete_file "_data/data-file-update.yml"
   end
 
   it "deletes a data file" do
-    path = File.expand_path "_data/data_file_delete.yml", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "foo: bar"
-    Jekyll::Admin.site.process
-
-    delete '/data/data_file_delete'
+    path = write_file "_data/data-file-delete.yml", "foo2: bar2"
+    delete '/data/data-file-delete'
     expect(last_response).to be_ok
     expect(File.exist?(path)).to eql(false)
   end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -59,8 +59,7 @@ describe "pages" do
   end
 
   it "writes a new page" do
-    path = File.expand_path "page-new.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
+    delete_file "page-new.md"
 
     request = {
       :meta => { :foo => "bar" },
@@ -71,13 +70,11 @@ describe "pages" do
     expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar')
 
-    File.delete(path)
+    delete_file "page-new.md"
   end
 
   it "updates a page" do
-    path = File.expand_path "page-update.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "---\n---\n\ntest"
+    write_file "page-update.md"
 
     request = {
       :meta => { :foo => "bar2" },
@@ -88,15 +85,32 @@ describe "pages" do
     expect(last_response).to be_ok
     expect(last_response_parsed["foo"]).to eq('bar2')
 
-    File.delete(path)
+    delete_file "page-update.md"
+  end
+
+  it "renames a page" do
+    write_file  "page-rename.md"
+    delete_file "page-renamed.md"
+
+    request = {
+      :path => "page-renamed.md",
+      :meta => { :foo => "bar" },
+      :body => "test"
+    }
+
+    put '/pages/page-rename.md', request.to_json
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar')
+
+    get '/pages/page-renamed.md'
+    expect(last_response).to be_ok
+    expect(last_response_parsed["foo"]).to eq('bar')
+
+    delete_file "page-rename.md", "page-renamed.md"
   end
 
   it "deletes a page" do
-    path = File.expand_path "page-delete.md", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "---\n---\n\ntest"
-    Jekyll::Admin.site.process
-
+    path = write_file "page-delete.md"
     delete '/pages/page-delete.md'
     expect(last_response).to be_ok
     expect(File.exist?(path)).to eql(false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,29 @@ def last_response_parsed
   JSON.parse(last_response.body)
 end
 
+# Deletes one or more files, if they exist within the site, and rebuilds it
+def delete_file(*paths)
+  paths.each do |path|
+    path = File.expand_path path, fixture_path("site")
+    File.delete(path) if File.exist?(path)
+  end
+  Jekyll::Admin.site.process
+end
+
+# Writes a file to path
+#
+# path - the path to the file, relative to the fixture site source
+# content - optional, content to write, defaulting to YAML front matter + markdown
+#
+# Rebuilds the site and returns the full path to the file
+def write_file(path, content = "---\n---\n\n# test")
+  delete_file path
+  path = File.expand_path path, fixture_path("site")
+  File.write path, content
+  Jekyll::Admin.site.process
+  path
+end
+
 config = Jekyll.configuration("source" => fixture_path("site"))
 site = Jekyll::Site.new(config)
 site.process

--- a/spec/static_file_spec.rb
+++ b/spec/static_file_spec.rb
@@ -24,8 +24,7 @@ describe "static_files" do
   end
 
   it "writes a static file" do
-    path = File.expand_path "static-file-new.txt", fixture_path("site")
-    File.delete(path) if File.exist?(path)
+    delete_file "static-file-new.txt"
 
     request = { :body => "test" }
     put '/static_files/static-file-new.txt', request.to_json
@@ -34,13 +33,11 @@ describe "static_files" do
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-file-new.txt")
 
-    File.delete(path)
+    delete_file "static-file-new.txt"
   end
 
   it "updates a static file" do
-    path = File.expand_path "static-file-update.txt", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "test2"
+    write_file "static-file-update.txt", "test2"
 
     request = { :body => "test" }
     put '/static_files/static-file-update.txt', request.to_json
@@ -49,15 +46,11 @@ describe "static_files" do
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-file-update.txt")
 
-    File.delete(path)
+    delete_file "static-file-update.txt"
   end
 
   it "deletes a static_file" do
-    path = File.expand_path "static-file-delete.txt", fixture_path("site")
-    File.delete(path) if File.exist?(path)
-    File.write path, "test"
-    Jekyll::Admin.site.process
-
+    path = write_file "static-file-delete.txt", "test"
     delete '/static_files/static-file-delete.txt'
     expect(last_response).to be_ok
     expect(File.exist?(path)).to eql(false)


### PR DESCRIPTION
There's a bit of noise here, as I DRY'd up the tests a bit, as I was adding new ones, but in short, given a PUT request to a page or document with a top-level `path` parameter (along side `meta` and `body`), the server will now properly rename the file.

Fixes https://github.com/jekyll/jekyll-admin/issues/57.
