### PR TITLE
Include raw front matter in API response

### DIFF
--- a/lib/jekyll/admin.rb
+++ b/lib/jekyll/admin.rb
@@ -15,8 +15,11 @@ require "jekyll/admin/server/configuration.rb"
 require "jekyll/admin/server/data.rb"
 require "jekyll/admin/server/page.rb"
 require "jekyll/admin/server/static_file.rb"
+require "jekyll/admin/apiable.rb"
+
 require_relative "./commands/serve"
 require_relative "./convertible_ext"
+require_relative "./document_ext"
 
 module Jekyll
   module Admin

--- a/lib/jekyll/admin/apiable.rb
+++ b/lib/jekyll/admin/apiable.rb
@@ -1,0 +1,35 @@
+module Jekyll
+  module Admin
+    # Abstract module to be included in Convertible and Document to provide
+    # additional, API-specific functionality without duplicating logic
+    module APIable
+      # Returns a hash suitable for use as an API response.
+      #
+      # 1. Adds the file's raw content to the `raw_content` field
+      # 2. Adds the file's raw YAML front matter to the `front_matter` field
+      #
+      # Returns a hash (which can then be to_json'd)
+      def to_api
+        output = to_liquid
+
+        # Pages don't have a hash method, but Documents do
+        file_path = if is_a?(Jekyll::Document)
+                      path
+                    else
+                      File.join(@base, @dir, name)
+                    end
+
+        content = File.read(file_path, Utils.merged_file_read_opts(site, {}))
+        if content =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+          content = $POSTMATCH
+          yaml = SafeYAML.load(Regexp.last_match(1))
+        end
+
+        output["raw_content"] = content.to_s
+        output["front_matter"] = yaml || {}
+
+        output
+      end
+    end
+  end
+end

--- a/lib/jekyll/admin/apiable.rb
+++ b/lib/jekyll/admin/apiable.rb
@@ -28,7 +28,7 @@ module Jekyll
         output["raw_content"] = content.to_s
         output["front_matter"] = yaml || {}
 
-        output
+        output.to_h
       end
     end
   end

--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -13,13 +13,13 @@ module Jekyll
 
         get "/:collection_id/documents" do
           ensure_collection
-          json collection.docs.map { |doc| document_for_api(doc).to_liquid }
+          json collection.docs.map(&:to_api)
         end
 
         get "/:collection_id/*" do
           ensure_document
           content_type :json
-          document_for_api.to_liquid.to_json
+          document.to_api.to_json
         end
 
         put "/:collection_id/*" do
@@ -27,7 +27,7 @@ module Jekyll
           File.write document_path, document_body
           site.process
           content_type :json
-          document_for_api.to_liquid.to_json
+          document.to_api.to_json
         end
 
         delete "/:collection_id/*" do
@@ -64,35 +64,6 @@ module Jekyll
         def ensure_document
           ensure_collection
           render_404 if document.nil?
-        end
-
-        # Returns a document suitable for to_liquid being called on for the API
-        # The document will be the document as seen by Jekyll, but:
-        #  1. without front matter defaults by
-        #  2. With a `raw_content` field added
-        def document_for_api(original_doc = document)
-          doc = original_doc.dup
-          doc.instance_variable_set "@data", {}
-
-          # If the file has YAML front matter, read it in
-          content = File.read(doc.path, Utils.merged_file_read_opts(site, {}))
-          if content =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
-            content = $POSTMATCH
-            data_file = SafeYAML.load(Regexp.last_match(1))
-            doc.merge_data!(data_file, :source => "YAML front matter") if data_file
-          end
-
-          # Return the unrendered markdown, see https://git.io/vKDTG
-          doc.merge_data!({ "raw_content" => content }, :source => "Jekyll Admin")
-
-          # Set date, title, slug, extension, etc.
-          doc.post_read
-
-          # Unless we explicitly create the drop, the resulting drop will be based on the
-          # original document, not the duplicated one, due to Ruby strangeness
-          doc.instance_variable_set "@to_liquid", Drops::DocumentDrop.new(doc)
-
-          doc
         end
       end
     end

--- a/lib/jekyll/admin/server/collection.rb
+++ b/lib/jekyll/admin/server/collection.rb
@@ -18,16 +18,14 @@ module Jekyll
 
         get "/:collection_id/*" do
           ensure_document
-          content_type :json
-          document.to_api.to_json
+          json document.to_api
         end
 
         put "/:collection_id/*" do
           ensure_collection
           File.write document_path, document_body
           site.process
-          content_type :json
-          document.to_api.to_json
+          json document.to_api
         end
 
         delete "/:collection_id/*" do

--- a/lib/jekyll/admin/server/page.rb
+++ b/lib/jekyll/admin/server/page.rb
@@ -3,18 +3,18 @@ module Jekyll
     class Server < Sinatra::Base
       namespace "/pages" do
         get do
-          json site.pages.map(&:to_liquid_without_frontmatter_defaults)
+          json site.pages.map(&:to_api)
         end
 
         get "/:page_id" do
           ensure_page
-          json page.to_liquid_without_frontmatter_defaults
+          json page.to_api
         end
 
         put "/:page_id" do
           File.write page_path, page_body
           site.process
-          json page.to_liquid_without_frontmatter_defaults
+          json page.to_api
         end
 
         delete "/:page_id" do

--- a/lib/jekyll/document_ext.rb
+++ b/lib/jekyll/document_ext.rb
@@ -1,5 +1,5 @@
 module Jekyll
-  module Convertible
+  class Document
     include Jekyll::Admin::APIable
   end
 end

--- a/spec/apiable_spec.rb
+++ b/spec/apiable_spec.rb
@@ -10,9 +10,9 @@ describe Jekyll::Admin::APIable do
         end
       end
 
-      let(:liquid) { subject.to_liquid }
-      let(:raw_content)  { subject.to_api["raw_content"] }
-      let(:front_matter) { subject.to_api["front_matter"] }
+      let(:as_api) { subject.to_api }
+      let(:raw_content)  { as_api["raw_content"] }
+      let(:front_matter) { as_api["front_matter"] }
 
       it "is responds to to_api" do
         expect(subject).to respond_to(:to_api)
@@ -33,8 +33,8 @@ describe Jekyll::Admin::APIable do
       end
 
       it "includes front matter defaults" do
-        expect(liquid).to have_key("some_front_matter")
-        expect(liquid["some_front_matter"]).to eql("default")
+        expect(as_api).to have_key("some_front_matter")
+        expect(as_api["some_front_matter"]).to eql("default")
       end
     end
   end

--- a/spec/apiable_spec.rb
+++ b/spec/apiable_spec.rb
@@ -28,11 +28,11 @@ describe Jekyll::Admin::APIable do
         expect(front_matter["foo"]).to eql("bar")
       end
 
-      it "doesn't include front matter defaults" do
+      it "doesn't include front matter defaults in the raw front matter" do
         expect(front_matter).to_not have_key("some_front_matter")
       end
 
-      it "includes front matter defaults" do
+      it "includes front matter defaults as top-level keys" do
         expect(as_api).to have_key("some_front_matter")
         expect(as_api["some_front_matter"]).to eql("default")
       end

--- a/spec/apiable_spec.rb
+++ b/spec/apiable_spec.rb
@@ -1,0 +1,41 @@
+describe Jekyll::Admin::APIable do
+  [:page, :post].each do |type|
+    context type do
+      subject do
+        documents = Jekyll.sites.first.send("#{self.class.description}s".to_sym)
+        if self.class.description == "page"
+          documents.first
+        else
+          documents.docs.first
+        end
+      end
+
+      let(:liquid) { subject.to_liquid }
+      let(:raw_content)  { subject.to_api["raw_content"] }
+      let(:front_matter) { subject.to_api["front_matter"] }
+
+      it "is responds to to_api" do
+        expect(subject).to respond_to(:to_api)
+      end
+
+      it "includes the raw_content" do
+        expected = self.class.description.capitalize
+        expect(raw_content).to eql("# Test #{expected}\n")
+      end
+
+      it "includes the raw front matter" do
+        expect(front_matter).to have_key("foo")
+        expect(front_matter["foo"]).to eql("bar")
+      end
+
+      it "doesn't include front matter defaults" do
+        expect(front_matter).to_not have_key("some_front_matter")
+      end
+
+      it "includes front matter defaults" do
+        expect(liquid).to have_key("some_front_matter")
+        expect(liquid["some_front_matter"]).to eql("default")
+      end
+    end
+  end
+end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -32,10 +32,17 @@ describe "collections" do
       expect(last_response_parsed.first["title"]).to eq('Test')
     end
 
-    it "doesn't include front matter defaults" do
+    it "includes front matter defaults" do
       get '/collections/posts/documents'
       expect(last_response).to be_ok
-      expect(last_response_parsed.first.key?("some_front_matter")).to eq(false)
+      expect(last_response_parsed.first.key?("some_front_matter")).to eq(true)
+    end
+
+    it "include the raw front matter" do
+      get '/collections/posts/documents'
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first.key?("front_matter")).to eq(true)
+      expect(last_response_parsed.first["front_matter"]["foo"]).to eql("bar")
     end
   end
 
@@ -76,9 +83,22 @@ describe "collections" do
       expect(last_response_parsed["raw_content"]).to eq("# Test Post\n")
     end
 
-    it "doesn't contain front matter defaults" do
-      get '/collections/posts/2016-01-01-test.md'
-      expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+    context "front matter" do
+      it "contains front matter defaults" do
+        get '/collections/posts/2016-01-01-test.md'
+        expect(last_response_parsed.key?("some_front_matter")).to eql(true)
+      end
+
+      it "contains raw front matter" do
+        get '/collections/posts/2016-01-01-test.md'
+        expect(last_response_parsed.key?("front_matter")).to eql(true)
+        expect(last_response_parsed["front_matter"]["foo"]).to eql("bar")
+      end
+
+      it "raw front matter doesn't contain defaults" do
+        get '/collections/posts/2016-01-01-test.md'
+        expect(last_response_parsed["front_matter"].key?("some_front_matter")).to eql(false)
+      end
     end
 
     it "404s for an unknown document" do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -20,10 +20,17 @@ describe "pages" do
       expect(last_response_parsed.last["name"]).to eq('page.md')
     end
 
-    it "doesn't include front matter defaults" do
+    it "includes front matter defaults" do
       get "/pages"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first.key?("some_front_matter")).to eq(false)
+      expect(last_response_parsed.first.key?("some_front_matter")).to eq(true)
+    end
+
+    it "incldues the raw front matter" do
+      get "/pages"
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first.key?("front_matter")).to eq(true)
+      expect(last_response_parsed.first["front_matter"]["foo"]).to eq("bar")
     end
   end
 
@@ -47,9 +54,22 @@ describe "pages" do
       expect(last_response_parsed["raw_content"]).to eq("# Test Page\n")
     end
 
-    it "doesn't contain front matter defaults" do
-      get "/pages/page.md"
-      expect(last_response_parsed.key?("some_front_matter")).to eql(false)
+    context "front matter" do
+      it "contains front matter defaults" do
+        get "/pages/page.md"
+        expect(last_response_parsed.key?("some_front_matter")).to eql(true)
+      end
+
+      it "contains raw front matter" do
+        get "/pages/page.md"
+        expect(last_response_parsed.key?("front_matter")).to eql(true)
+        expect(last_response_parsed["front_matter"]["foo"]).to eql("bar")
+      end
+
+      it "raw front matter doesn't include defaults" do
+        get "/pages/page.md"
+        expect(last_response_parsed["front_matter"].key?("some_front_matter")).to eql(false)
+      end
     end
 
     it "404s for an unknown page" do


### PR DESCRIPTION
Chatting with @mertkahyaoglu this PR changes the structure of the response hash to include a `front_matter` field, which includes the raw front matter, without defaults or computed fields (e.g., what's in the file). 

Additionally, the API now includes front matter and computed fields (the raw `to_liquid` output) as top-level keys. Doing so allows us to simplify and centralize how we generate the response hash for Pages and Documents, including the new `raw_content` logic in a single read operation.

To do so, I introduced an `APIable` module, which can be included in `Convertible` and `Document`, to add a a`to_api` method, which we call to consistently convert a Jekyll object to a hash suitable for the API. This way we have our logic in one place and can add it to any Jekyll object we want.