### PR TITLE
Clean up monkey patching

### DIFF
--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -26,7 +26,7 @@ require "jekyll-admin/apiable.rb"
 
 # Monkey Patches
 require_relative "./jekyll/commands/serve"
-[Jekyll::Convertible, Jekyll::Document].each do |klass|
+[Jekyll::Page, Jekyll::Document].each do |klass|
   klass.include JekyllAdmin::APIable
 end
 

--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -1,3 +1,9 @@
+# Default Sinatra to "production" mode (surpress errors) unless
+# otherwise specified by the `RACK_ENV` environmental variable.
+# Must be done prior to requiring Sinatra, or we'll get a LoadError
+# as it looks for sinatra/cross-origin, which is development only
+ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
+
 require "json"
 require "jekyll"
 require "webrick"
@@ -23,10 +29,6 @@ require_relative "./jekyll/commands/serve"
 [Jekyll::Convertible, Jekyll::Document].each do |klass|
   klass.include JekyllAdmin::APIable
 end
-
-# Default Sinatra to "production" mode (surpress errors) unless
-# otherwise specified by the `RACK_ENV` environmental variable
-ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
 
 module JekyllAdmin
   def self.site

--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -20,8 +20,13 @@ require "jekyll-admin/apiable.rb"
 
 # Monkey Patches
 require_relative "./jekyll/commands/serve"
-require_relative "./jekyll/convertible_ext"
-require_relative "./jekyll/document_ext"
+[Jekyll::Convertible, Jekyll::Document].each do |klass|
+  klass.include JekyllAdmin::APIable
+end
+
+# Default Sinatra to "production" mode (surpress errors) unless
+# otherwise specified by the `RACK_ENV` environmental variable
+ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
 
 module JekyllAdmin
   def self.site

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -18,14 +18,16 @@ module JekyllAdmin
                     File.join(@base, @dir, name)
                   end
 
-      content = File.read(file_path, Jekyll::Utils.merged_file_read_opts(site, {}))
-      if content =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
-        content = $POSTMATCH
-        yaml = SafeYAML.load(Regexp.last_match(1))
-      end
+      if File.exists?(file_path)
+        content = File.read(file_path, Jekyll::Utils.merged_file_read_opts(site, {}))
+        if content =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+          content = $POSTMATCH
+          yaml = SafeYAML.load(Regexp.last_match(1))
+        end
 
-      output["raw_content"] = content.to_s
-      output["front_matter"] = yaml || {}
+        output["raw_content"] = content.to_s
+        output["front_matter"] = yaml || {}
+      end
 
       output.to_h
     end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -18,10 +18,6 @@ module Jekyll
         end
 
         def jekyll_admin_monkey_patch(server)
-          # Default Sinatra to "production" mode (surpress errors) unless
-          # otherwise specified by the `RACK_ENV` environmental variable
-          ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
-
           server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
           server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
         end

--- a/lib/jekyll/convertible_ext.rb
+++ b/lib/jekyll/convertible_ext.rb
@@ -1,5 +1,0 @@
-module Jekyll
-  module Convertible
-    include JekyllAdmin::APIable
-  end
-end

--- a/lib/jekyll/document_ext.rb
+++ b/lib/jekyll/document_ext.rb
@@ -1,5 +1,0 @@
-module Jekyll
-  class Document
-    include JekyllAdmin::APIable
-  end
-end


### PR DESCRIPTION
Since we're just monkey patching Document and Convertible by including a module, we can clean things up a bit, by extending them programmatically, rather than with dedicated, one-line files.

This also moves the `RACK_ENV` default to the JekyllAdmin module, to keep the monkey patch of `commands/serve` as small as possible.