### PR TITLE
Add script/console

### DIFF
--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop", "~> 0.35"
   spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"
+  spec.add_development_dependency "pry", "~> 0.10"
 end

--- a/script/console
+++ b/script/console
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+ENV["RACK_ENV"] = "development"
+require 'pry'
+require "jekyll-admin"
+require 'rack/test'
+
+class Session
+  include Rack::Test::Methods
+  attr_reader :app
+
+  def initialize(app)
+    @app = app
+  end
+end
+
+path = File.expand_path "../spec/fixtures/site", File.dirname(__FILE__)
+config = Jekyll.configuration("source" => path)
+site = Jekyll::Site.new(config)
+site.process
+app = Session.new(JekyllAdmin::Server)
+
+puts "You're all set. You can access the server as `app` and the site as `site`..."
+
+binding.pry

--- a/script/console
+++ b/script/console
@@ -22,4 +22,4 @@ app = Session.new(JekyllAdmin::Server)
 
 puts "You're all set. You can access the server as `app` and the site as `site`..."
 
-binding.pry(false)
+Pry.start binding, :quiet => true

--- a/script/console
+++ b/script/console
@@ -22,4 +22,4 @@ app = Session.new(JekyllAdmin::Server)
 
 puts "You're all set. You can access the server as `app` and the site as `site`..."
 
-binding.pry
+binding.pry(false)


### PR DESCRIPTION
This adds a quick `script/console` command for local debugging.

e.g.

```
➜  jekyll-admin git:(script-console) ✗ bundle exec script/console
Configuration file: /Users/benbalter/github/jekyll-admin/spec/fixtures/site/_config.yml
You're all set. You can access the server as `app` and the site as `site`...

[1] pry(main)> site.pages.first.to_api
=> {"some_front_matter"=>"default",
 "foo"=>"bar",
 "content"=>"<h1 id=\"test-page\">Test Page</h1>\n",
 "dir"=>"/",
 "name"=>"page.md",
 "path"=>"page.md",
 "url"=>"/page.html",
 "raw_content"=>"# Test Page\n",
 "front_matter"=>{"foo"=>"bar"}}

[2] pry(main)> puts app.get("/").body
{"collections_api":"http://example.org/_api/collections","configuration_api":"http://example.org/_api/configuration","data_api":"http://example.org/_api/data","pages_api":"http://example.org/_api/pages","static_files_api":"http://example.org/_api/static_files"}
=> nil
```