### PR TITLE
Standarize on raw_content and front_matter keys

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,13 +4,61 @@ The below are the documented endpoints of the shared HTTP API. All requests and 
 
 For simplicity, whenever possible, the API mirrors Jekyll internal data structures, meaning, objects are generally the results of calling `.to_liquid.to_json` on an existing Jekyll model (and the resulting fields).
 
+### API Request and response payloads
+
+#### Pages and Documents
+
+Pages and documents are JSON objects resulting from calling `to_liquid.to_json` on the underlying Jekyll object.
+
+The resulting JSON object has the following structure:
+
+* Top level keys are keys with special meaning. This includes:
+  * Computed, read-only keys like `url`
+  * Computed, read/write keys like `path`
+  * Front matter defaults
+* The top-level namespace will have `content` and `raw_content` keys with the HTML and markdown respectively
+* The top-level namespace will have a `front_matter` key which includes the raw front matter as seen on disk.
+
+A standard page may then look like this:
+
+```json
+{
+   "some_front_matter":"default",
+   "foo":"bar",
+   "content":"<h1 id=\"test-page\">Test Page</h1>\n",
+   "dir":"/",
+   "name":"page.md",
+   "path":"page.md",
+   "url":"/page.html",
+   "raw_content":"# Test Page\n",
+   "front_matter":{
+      "foo":"bar"
+   }
+}
+```
+
+When making a request, clients can set the following top-level fields:
+
+* `raw_content` - the raw, unrendered content to be written to disk (currently `body`)
+* `front_matter` - the entire YAML front matter object to be written to disk (currently `meta`)
+* `path` - the new file path relative to the site source, if the file is to be renamed
+
+#### Data files and the config file
+
+Data files and the config file are direct JSON representations of the underlying YAML File.
+
+#### Static files
+
+Static files are just the raw content and may be binary.
+
 ### Collections
+
 #### Parameters
 
 * `collection_name` - the name of the collection, e.g., posts (`String`)
-* `id` - the filename of a document, relative to the collection root (e.g., `2016-01-01-some-post.md` or `rover.md`) (`String`)
-* `body` - the document body (`String`)
-* `meta` - the document's YAML front matter (`Object`)
+* `path` - the filename of a document, relative to the collection root (e.g., `2016-01-01-some-post.md` or `rover.md`) (`String`)
+* `raw_content` - the document body (`String`)
+* `front_matter` - the document's YAML front matter (`Object`)
 
 #### `GET /collections/`
 
@@ -24,15 +72,15 @@ Returns information about the requested collection
 
 Return an array of document objects corresponding to the requested collection. The response does not include the document body.
 
-#### `GET /collections/:collection_name/:id`
+#### `GET /collections/:collection_name/:path`
 
 Returns the requested document. The response includes the document body.
 
-#### `PUT /collections/:collection_name/:id`
+#### `PUT /collections/:collection_name/:path`
 
 Create or update the requested document, writing its contents to disk.
 
-#### `DELETE /collections/:collection_name/:id`
+#### `DELETE /collections/:collection_name/:path`
 
 Delete the requested document from disk.
 
@@ -40,23 +88,23 @@ Delete the requested document from disk.
 
 #### Parameters
 
-* `id` - The file's path, relative to the site root (e.g., `about.html`) (`String`)
-* `body` - the page's body (`String`)
-* `meta` - the page's YAML front matter (`Object`)
+* `path` - The file's path, relative to the site root (e.g., `about.html`) (`String`)
+* `raw_content` - the page's body (`String`)
+* `front_matter` - the page's YAML front matter (`Object`)
 
 #### `GET /pages`
 
 Return an array of page objects. The response does not include the page body.
 
-#### `GET /pages/:id`
+#### `GET /pages/:path`
 
 Returns the requested page. The response includes the page body.
 
-#### `PUT /pages/:id`
+#### `PUT /pages/:path`
 
 Create or update the requested page, writing its contents to disk.
 
-#### `DELETE /pages/:id`
+#### `DELETE /pages/:path`
 
 Delete the requested page from disk.
 

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -55,13 +55,13 @@ module JekyllAdmin
     end
 
     def document_body
-      body = if request_payload["meta"]
-               YAML.dump(request_payload["meta"]).strip
+      body = if request_payload["front_matter"]
+               YAML.dump(request_payload["front_matter"]).strip
              else
                "---"
              end
       body << "\n---\n\n"
-      body << request_payload["body"].to_s
+      body << request_payload["raw_content"].to_s
     end
     alias page_body document_body
   end

--- a/spec/apiable_spec.rb
+++ b/spec/apiable_spec.rb
@@ -11,6 +11,7 @@ describe JekyllAdmin::APIable do
       end
 
       let(:as_api) { subject.to_api }
+      let(:content)  { as_api["content"] }
       let(:raw_content)  { as_api["raw_content"] }
       let(:front_matter) { as_api["front_matter"] }
 
@@ -21,6 +22,12 @@ describe JekyllAdmin::APIable do
       it "includes the raw_content" do
         expected = self.class.description.capitalize
         expect(raw_content).to eql("# Test #{expected}\n")
+      end
+
+      it "includes the rendered content" do
+        type = self.class.description
+        expected = "<h1 id=\"test-#{type}\">Test #{type.capitalize}</h1>\n"
+        expect(content).to eql(expected)
       end
 
       it "includes the raw front matter" do
@@ -35,6 +42,10 @@ describe JekyllAdmin::APIable do
       it "includes front matter defaults as top-level keys" do
         expect(as_api).to have_key("some_front_matter")
         expect(as_api["some_front_matter"]).to eql("default")
+      end
+
+      it "includes front matter as top-level keys" do
+        expect(as_api["foo"]).to eql("bar")
       end
     end
   end

--- a/spec/jekyll-admin/collection_spec.rb
+++ b/spec/jekyll-admin/collection_spec.rb
@@ -116,8 +116,8 @@ describe "collections" do
     delete_file "_posts/2016-01-01-test2.md"
 
     request = {
-      :meta => { :foo => "bar" },
-      :body => "test"
+      :front_matter => { :foo => "bar" },
+      :raw_content => "test"
     }
     put '/collections/posts/2016-01-01-test2.md', request.to_json
 
@@ -132,8 +132,8 @@ describe "collections" do
     write_file "_posts/2016-01-01-test2.md"
 
     request = {
-      :meta => { :foo => "bar2" },
-      :body => "test"
+      :front_matter => { :foo => "bar2" },
+      :raw_content => "test"
     }
     put '/collections/posts/2016-01-01-test2.md', request.to_json
 
@@ -154,8 +154,8 @@ describe "collections" do
         path = path.prepend("_posts/") if type == "with"
         request = {
           :path => path,
-          :meta => { :foo => "bar2" },
-          :body => "test"
+          :front_matter => { :foo => "bar2" },
+          :raw_content => "test"
         }
 
         put '/collections/posts/2016-01-01-test2.md', request.to_json

--- a/spec/jekyll-admin/collection_spec.rb
+++ b/spec/jekyll-admin/collection_spec.rb
@@ -119,7 +119,7 @@ describe "collections" do
 
     request = {
       :front_matter => { :foo => "bar" },
-      :raw_content => "test"
+      :raw_content  => "test"
     }
     put "/collections/posts/2016-01-01-test2.md", request.to_json
 
@@ -135,7 +135,7 @@ describe "collections" do
 
     request = {
       :front_matter => { :foo => "bar2" },
-      :raw_content => "test"
+      :raw_content  => "test"
     }
     put "/collections/posts/2016-01-01-test2.md", request.to_json
 
@@ -155,9 +155,9 @@ describe "collections" do
         path = "2016-01-02-test2.md"
         path = path.prepend("_posts/") if type == "with"
         request = {
-          :path => path,
+          :path         => path,
           :front_matter => { :foo => "bar2" },
-          :raw_content => "test"
+          :raw_content  => "test"
         }
 
         put "/collections/posts/2016-01-01-test2.md", request.to_json

--- a/spec/jekyll-admin/page_spec.rb
+++ b/spec/jekyll-admin/page_spec.rb
@@ -85,7 +85,7 @@ describe "pages" do
 
     request = {
       :front_matter => { :foo => "bar" },
-      :raw_content => "test"
+      :raw_content  => "test"
     }
     put "/pages/page-new.md", request.to_json
 
@@ -101,7 +101,7 @@ describe "pages" do
 
     request = {
       :front_matter => { :foo => "bar2" },
-      :raw_content => "test"
+      :raw_content  => "test"
     }
     put "/pages/page-update.md", request.to_json
     expect("page-update.md").to be_an_existing_file
@@ -117,9 +117,9 @@ describe "pages" do
     delete_file "page-renamed.md"
 
     request = {
-      :path => "page-renamed.md",
+      :path         => "page-renamed.md",
       :front_matter => { :foo => "bar" },
-      :raw_content => "test"
+      :raw_content  => "test"
     }
 
     put "/pages/page-rename.md", request.to_json

--- a/spec/jekyll-admin/page_spec.rb
+++ b/spec/jekyll-admin/page_spec.rb
@@ -82,8 +82,8 @@ describe "pages" do
     delete_file "page-new.md"
 
     request = {
-      :meta => { :foo => "bar" },
-      :body => "test"
+      :front_matter => { :foo => "bar" },
+      :raw_content => "test"
     }
     put '/pages/page-new.md', request.to_json
 
@@ -98,8 +98,8 @@ describe "pages" do
     write_file "page-update.md"
 
     request = {
-      :meta => { :foo => "bar2" },
-      :body => "test"
+      :front_matter => { :foo => "bar2" },
+      :raw_content => "test"
     }
     put '/pages/page-update.md', request.to_json
     expect("page-update.md").to be_an_existing_file
@@ -116,8 +116,8 @@ describe "pages" do
 
     request = {
       :path => "page-renamed.md",
-      :meta => { :foo => "bar" },
-      :body => "test"
+      :front_matter => { :foo => "bar" },
+      :raw_content => "test"
     }
 
     put '/pages/page-rename.md', request.to_json


### PR DESCRIPTION
This PR changes the `meta` field to `front_matter` and `body` field to `raw_content` in expected request payloads to match the response payload.

Fixes https://github.com/jekyll/jekyll-admin/issues/82.