### PR TITLE
Run Node and Ruby tests in parallel on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ cache:
   directories:
     - node_modules
 sudo: false
+env:
+  matrix:
+    - TEST_SUITE=node
+    - TEST_SUITE=ruby

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,5 +3,15 @@
 set -e
 
 script/branding
-script/cibuild-node
-script/cibuild-ruby
+
+if [[ -z "$TEST_SUITE" ]]
+then
+  script/cibuild-node
+  script/cibuild-ruby
+elif [[ -x "script/cibuild-$TEST_SUITE" ]]
+then
+  script/cibuild-$TEST_SUITE
+else
+  echo "Unknown test suite."
+  exit 1
+fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,11 +4,11 @@ set -e
 
 script/branding
 
-if [[ -z "$TEST_SUITE" ]]
+if [ -z "$TEST_SUITE" ]
 then
   script/cibuild-node
   script/cibuild-ruby
-elif [[ -x "script/cibuild-$TEST_SUITE" ]]
+elif [ -x "script/cibuild-$TEST_SUITE" ]
 then
   script/cibuild-$TEST_SUITE
 else

--- a/script/cibuild-ruby
+++ b/script/cibuild-ruby
@@ -3,7 +3,10 @@
 set -e
 
 if [ ! -d "./lib/jekyll-admin/public/dist" ]; then
-  script/build
+  echo "Frontend not build. Stubbing in a front end for testing."
+  echo "Run script/build to compile the front end."
+  mkdir -p "./lib/jekyll-admin/public/dist"
+  echo "Run script/build to build the front end" > "./lib/jekyll-admin/public/dist/index.html"
 fi
 
 echo "Running Ruby tests..."

--- a/script/test-server
+++ b/script/test-server
@@ -5,5 +5,9 @@ set -e
 script/branding
 script/return-to-pwd
 
+if [ ! -d "./lib/jekyll-admin/public/dist" ]; then
+  script/build
+fi
+
 cd ./spec/fixtures/site || exit
 RACK_ENV=development bundle exec jekyll serve --verbose

--- a/spec/jekyll-admin/static_server_spec.rb
+++ b/spec/jekyll-admin/static_server_spec.rb
@@ -8,12 +8,14 @@ describe JekyllAdmin::StaticServer do
   it "returns the index" do
     get "/"
     expect(last_response).to be_ok
-    expect(last_response.body).to match(%r!<body>!)
+    expected = "Run script/build to build the front end\n"
+    expect(last_response.body).to eql(expected)
   end
 
   it "returns the index for non-existent paths" do
     get "/collections"
     expect(last_response).to be_ok
-    expect(last_response.body).to match(%r!<body>!)
+    expected = "Run script/build to build the front end\n"
+    expect(last_response.body).to eql(expected)
   end
 end


### PR DESCRIPTION
Mostly stolen from `jekyll/jekyll`, this PR *should* run the Node and Ruby tests in parallel on Travis, so that (A) you can see their status independently and (B) you get feedback faster.