### PR TITLE
Stub public/dist/index.html for Ruby tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,8 +23,9 @@ There is a site in `spec/fixtures/site`, with some dummy content. The below loca
 
 If you just want to click around and see how things work, or if you've making changes to the backend Ruby side of things, this is probably what you want.
 
-1. Run `script/test-server`
-2. Open `http://localhost:4000/admin` in your browser (or `http://localhost:4000/_api`)
+1. Run `script/build` to compile the static frontend
+2. Run `script/test-server` to start the server
+3. Open `http://localhost:4000/admin` in your browser (or `http://localhost:4000/_api`)
 
 #### Running the front end server in development mode
 

--- a/lib/jekyll-admin/static_server.rb
+++ b/lib/jekyll-admin/static_server.rb
@@ -2,9 +2,17 @@ module JekyllAdmin
   class StaticServer < Sinatra::Base
     set :public_dir, File.expand_path("./public/dist", File.dirname(__FILE__))
 
+    MUST_BUILD_MESSAGE = "Front end not yet built. Run `script/build` to build.".freeze
+
     # Allow `/admin` and `/admin/`, and `/admin/*` to serve `/public/dist/index.html`
     get "/*" do
       send_file index_path
+    end
+
+    # Provide a descriptive error message in dev. if frontend is not build
+    not_found do
+      status 404
+      MUST_BUILD_MESSAGE if settings.development? || settings.test?
     end
 
     private

--- a/script/cibuild-ruby
+++ b/script/cibuild-ruby
@@ -2,13 +2,6 @@
 
 set -e
 
-if [ ! -d "./lib/jekyll-admin/public/dist" ]; then
-  echo "Frontend not build. Stubbing in a front end for testing."
-  echo "Run script/build to compile the front end."
-  mkdir -p "./lib/jekyll-admin/public/dist"
-  echo "Run script/build to build the front end" > "./lib/jekyll-admin/public/dist/index.html"
-fi
-
 echo "Running Ruby tests..."
 RACK_ENV=test JEKYLL_LOG_LEVEL=warn bundle exec rspec
 script/fmt

--- a/script/test-server
+++ b/script/test-server
@@ -5,9 +5,5 @@ set -e
 script/branding
 script/return-to-pwd
 
-if [ ! -d "./lib/jekyll-admin/public/dist" ]; then
-  script/build
-fi
-
 cd ./spec/fixtures/site || exit
 RACK_ENV=development bundle exec jekyll serve --verbose

--- a/spec/fixtures/index.html
+++ b/spec/fixtures/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Jekyll Admin</title>
+    <link rel="shortcut icon" href="favicon.ico">
+  <link rel="stylesheet" href="/admin/styles.css"></head>
+  <body>
+    <div id="root"></div>
+    <script src="/admin/bundle.js"></script>
+  </body>
+</html>

--- a/spec/jekyll-admin/static_server_spec.rb
+++ b/spec/jekyll-admin/static_server_spec.rb
@@ -6,16 +6,20 @@ describe JekyllAdmin::StaticServer do
   end
 
   it "returns the index" do
-    get "/"
-    expect(last_response).to be_ok
-    expected = "Run script/build to build the front end\n"
-    expect(last_response.body).to eql(expected)
+    with_index_stubbed do
+      get "/"
+      expect(last_response).to be_ok
+      expected = File.read(index_path)
+      expect(last_response.body).to eql(expected)
+    end
   end
 
   it "returns the index for non-existent paths" do
-    get "/collections"
-    expect(last_response).to be_ok
-    expected = "Run script/build to build the front end\n"
-    expect(last_response.body).to eql(expected)
+    with_index_stubbed do
+      get "/collections"
+      expect(last_response).to be_ok
+      expected = File.read(index_path)
+      expect(last_response.body).to eql(expected)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ ENV["RACK_ENV"] = "test"
 require "rspec"
 require "jekyll-admin"
 require "rack/test"
+require "fileutils"
 
 RSpec.configure do |conf|
   conf.include Rack::Test::Methods
@@ -10,6 +11,26 @@ end
 
 def fixture_path(fixture)
   File.expand_path "./fixtures/#{fixture}", File.dirname(__FILE__)
+end
+
+def dist_path
+  File.expand_path "../lib/jekyll-admin/public/dist/", File.dirname(__FILE__)
+end
+
+def index_path
+  File.expand_path "index.html", dist_path
+end
+
+def stub_index
+  FileUtils.mkdir_p(dist_path)
+  FileUtils.cp fixture_path("index.html"), index_path
+end
+
+def with_index_stubbed
+  return yield if File.exist?(index_path)
+  stub_index
+  yield
+  FileUtils.rm_f(index_path)
 end
 
 def in_source_dir(questionable_path)


### PR DESCRIPTION
This changes the behavior of `script/test-server` and `script/cibuild-ruby:`

* `script/test-server` no longer compiles the front end. If it's not complied, you'll get a descriptive error message on your first page load telling you to run `script/build`.

* If the front end *is* compiled when `script/cibuild-ruby` is run, it'll simply verify that requests for `/` and `/collections` (a random path) serve whatever's in `dist/index.html`.

* If the front end *isn't* compiled when `script/cibuild` is run, it'll temporarily stub a dummy file into `public/dist/index.html`, run the test, and then remove the file.

I've updated the docs to reflect the need to run `script/build` before first running `script/test-server`.

Fixes https://github.com/jekyll/jekyll-admin/issues/87.

