### PR TITLE
Add index to fixture site

### DIFF
--- a/spec/fixtures/site/index.html
+++ b/spec/fixtures/site/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    You're probably looking for <a href="/admin"><code>/admin</code></a>.
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a simple `index.html` file to the fixture site, so if you visit `http://localhost:4000` you're linked to `/admin` to help contributors test things out with a little less developer friction.