### PR TITLE
Don't blow up when posts or pages dont have front matter

### DIFF
--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -56,9 +56,13 @@ module JekyllAdmin
       Jekyll.sanitized_path JekyllAdmin.site.source, questionable_path
     end
 
+    def front_matter
+      request_payload["front_matter"]
+    end
+
     def document_body
-      body = if request_payload["front_matter"]
-               YAML.dump(request_payload["front_matter"]).strip
+      body = if front_matter && !front_matter.empty?
+               YAML.dump(front_matter).strip
              else
                "---"
              end

--- a/spec/jekyll-admin/collection_spec.rb
+++ b/spec/jekyll-admin/collection_spec.rb
@@ -114,7 +114,22 @@ describe "collections" do
     end
   end
 
-  it "writes a new file" do
+  it "writes a new file without front matter" do
+    delete_file "_posts/2016-01-01-test2.md"
+
+    request = {
+      :front_matter => {},
+      :raw_content  => "test"
+    }
+    put "/collections/posts/2016-01-01-test2.md", request.to_json
+
+    expect(last_response).to be_ok
+    expect("_posts/2016-01-01-test2.md").to be_an_existing_file
+
+    delete_file "_posts/2016-01-01-test2.md"
+  end
+
+  it "writes a new file with front matter" do
     delete_file "_posts/2016-01-01-test2.md"
 
     request = {

--- a/spec/jekyll-admin/page_spec.rb
+++ b/spec/jekyll-admin/page_spec.rb
@@ -80,7 +80,22 @@ describe "pages" do
     end
   end
 
-  it "writes a new page" do
+  it "writes a new page without front matter" do
+    delete_file "page-new.md"
+
+    request = {
+      :front_matter => {},
+      :raw_content  => "test"
+    }
+    put "/pages/page-new.md", request.to_json
+
+    expect(last_response).to be_ok
+    expect("page-new.md").to be_an_existing_file
+
+    delete_file "page-new.md"
+  end
+
+  it "writes a new page with front matter" do
     delete_file "page-new.md"
 
     request = {


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-admin/issues/91.

TL;DR: 

```json
{
  "front_matter": {},
  "raw_content": "foo"
}
```

Was being saved as:

```yaml
---
{}
---

foo
```

This fixes that, by ensuring that we always right valid front matter.