### PR TITLE
Fix searching documents/pages

### DIFF
--- a/lib/jekyll-admin/public/src/actions/tests/utils.spec.js
+++ b/lib/jekyll-admin/public/src/actions/tests/utils.spec.js
@@ -6,7 +6,7 @@ describe('Actions::Utils', () => {
   it('creates SEARCH_CONTENT', () => {
     const input = 'Finish docs';
     const expectedAction = { type: types.SEARCH_CONTENT, input };
-    expect(actions.searchByTitle(input)).toEqual(expectedAction);
+    expect(actions.search(input)).toEqual(expectedAction);
   });
 
   it('creates VALIDATION_ERROR', () => {

--- a/lib/jekyll-admin/public/src/actions/utils.js
+++ b/lib/jekyll-admin/public/src/actions/utils.js
@@ -1,6 +1,6 @@
 import * as ActionTypes from '../constants/actionTypes';
 
-export function searchByTitle(input) {
+export function search(input) {
   return {
     type: ActionTypes.SEARCH_CONTENT,
     input

--- a/lib/jekyll-admin/public/src/components/form/InputSearch.js
+++ b/lib/jekyll-admin/public/src/components/form/InputSearch.js
@@ -3,23 +3,25 @@ import React, { Component, PropTypes } from 'react';
 export default class InputSearch extends Component {
 
   handleKeyPress(event) {
-    const { searchByTitle } = this.props;
+    const { search } = this.props;
     if (event.charCode == 13) {
-      searchByTitle(event.target.value);
+      search(event.target.value);
     }
   }
 
   render() {
+    const { searchBy } = this.props;
     return (
       <input
         onKeyPress={(e) => this.handleKeyPress(e)}
         type="text"
         className="field"
-        placeholder="Search by title" />
+        placeholder={`Search by ${searchBy}`} />
     );
   }
 }
 
 InputSearch.propTypes = {
-  searchByTitle: PropTypes.func.isRequired
+  search: PropTypes.func.isRequired,
+  searchBy: PropTypes.string.isRequired
 };

--- a/lib/jekyll-admin/public/src/components/form/tests/inputsearch.spec.js
+++ b/lib/jekyll-admin/public/src/components/form/tests/inputsearch.spec.js
@@ -5,21 +5,34 @@ import { mount } from 'enzyme';
 import InputSearch from '../InputSearch';
 
 function setup() {
-  let actions = {
-    searchByTitle: expect.createSpy()
+  const actions = {
+    search: expect.createSpy()
   };
 
-  let component = mount(
-    <InputSearch {...actions} />
+  const props = {
+    searchBy: "title"
+  };
+
+  const component = mount(
+    <InputSearch {...props} {...actions} />
   );
 
-  return {component, actions};
+  return {
+    component,
+    input: component.find('input'),
+    actions,
+    props
+  };
 }
 
 describe('Components::InputSearch', () => {
   it('should call searchByTitle', () => {
+    const { input, props } = setup();
+    expect(input.prop('placeholder')).toBe(`Search by ${props.searchBy}`);
+  });
+  it('should call searchByTitle', () => {
     const { component, actions } = setup();
     component.simulate('keypress', { charCode: 13 });
-    expect(actions.searchByTitle).toHaveBeenCalled();
+    expect(actions.search).toHaveBeenCalled();
   });
 });

--- a/lib/jekyll-admin/public/src/containers/views/Documents.js
+++ b/lib/jekyll-admin/public/src/containers/views/Documents.js
@@ -14,10 +14,10 @@ import InputSearch from '../../components/form/InputSearch';
 
 // Actions
 import { fetchDocuments, deleteDocument } from '../../actions/collections';
-import { searchByTitle } from '../../actions/utils';
+import { search } from '../../actions/utils';
 
 // Selectors
-import { filterByTitle } from '../../reducers/utils';
+import { filterByTitle } from '../../reducers/collections';
 
 export class Documents extends Component {
 
@@ -41,6 +41,23 @@ export class Documents extends Component {
     }
   }
 
+  renderTable() {
+    return (
+      <div className="content-table">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Date</th>
+              <th className="th-actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody>{this.renderRows()}</tbody>
+        </table>
+      </div>
+    );
+  }
+
   renderRows() {
     const { currentDocuments } = this.props;
     return _.map(currentDocuments, (doc) => {
@@ -51,14 +68,10 @@ export class Documents extends Component {
         <tr key={id}>
           <td className="row-title">
             <strong>
-              <Link to={to}>
-                {title || id}
-              </Link>
+              <Link to={to}>{title}</Link>
             </strong>
           </td>
-          <td>
-            {dateformat(doc.date, "mmm dd, yyyy")}
-          </td>
+          <td>{dateformat(doc.date, "mmm dd, yyyy")}</td>
           <td>
             <div className="row-actions">
               <a onClick={() => this.handleClickDelete(filename, collection)} title="Delete">
@@ -75,15 +88,12 @@ export class Documents extends Component {
   }
 
   render() {
-    const { isFetching, currentDocuments, searchByTitle, message, params } = this.props;
-    let { collection_name } = params;
+    const { isFetching, currentDocuments, search, message, params } = this.props;
+    const { collection_name } = params;
 
     if (isFetching) {
       return null;
     }
-
-    if (!currentDocuments.length)
-      return <h1>{`You don't have any documents for this collection.`}</h1>;
 
     return (
       <div>
@@ -94,21 +104,15 @@ export class Documents extends Component {
           </div>
           <strong className="message">{message}</strong>
           <div className="side-unit pull-right">
-            <InputSearch searchByTitle={searchByTitle} />
+            <InputSearch searchBy="title" search={search} />
           </div>
         </div>
-        <div className="content-table">
-          <table>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Date</th>
-                <th className="th-actions">Actions</th>
-              </tr>
-            </thead>
-            <tbody>{this.renderRows()}</tbody>
-          </table>
-        </div>
+        {
+          currentDocuments.length > 0 && this.renderTable()
+        }
+        {
+          !currentDocuments.length && <h1>{`You don't have any documents.`}</h1>
+        }
       </div>
     );
   }
@@ -120,7 +124,7 @@ Documents.propTypes = {
   fetchDocuments: PropTypes.func.isRequired,
   deleteDocument: PropTypes.func.isRequired,
   message: PropTypes.string.isRequired,
-  searchByTitle: PropTypes.func.isRequired,
+  search: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired
 };
 
@@ -137,7 +141,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({
     fetchDocuments,
     deleteDocument,
-    searchByTitle
+    search
   }, dispatch);
 }
 

--- a/lib/jekyll-admin/public/src/containers/views/Pages.js
+++ b/lib/jekyll-admin/public/src/containers/views/Pages.js
@@ -12,10 +12,10 @@ import InputSearch from '../../components/form/InputSearch';
 
 // Actions
 import { fetchPages, deletePage } from '../../actions/pages';
-import { searchByTitle } from '../../actions/utils';
+import { search } from '../../actions/utils';
 
 // Selectors
-import { filterByTitle } from '../../reducers/utils';
+import { filterByFilename } from '../../reducers/pages';
 
 export class Pages extends Component {
 
@@ -32,14 +32,33 @@ export class Pages extends Component {
     }
   }
 
+  renderTable() {
+    return (
+      <div className="content-table">
+        <table>
+          <thead>
+            <tr>
+              <th>Filename</th>
+              <th className="th-actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody>{this.renderRows()}</tbody>
+        </table>
+      </div>
+    );
+  }
+
   renderRows() {
     const { pages } = this.props;
     return _.map(pages, (page) => {
-      let { name, url, title } = page;
+      const { name, url, title } = page;
+      const to = `${ADMIN_PREFIX}/pages/${name}`;
       return (
         <tr key={name}>
           <td className="row-title">
-            <strong><Link to={`${ADMIN_PREFIX}/pages/${name}`}>{title || name}</Link></strong>
+            <strong>
+              <Link to={to}>{name}</Link>
+            </strong>
           </td>
           <td>
             <div className="row-actions">
@@ -57,14 +76,11 @@ export class Pages extends Component {
   }
 
   render() {
-    const { isFetching, pages, searchByTitle, message } = this.props;
+    const { isFetching, pages, search, message } = this.props;
 
     if (isFetching) {
       return null;
     }
-
-    if (!pages.length)
-      return <h1>{`You don't have any pages.`}</h1>;
 
     return (
       <div>
@@ -75,20 +91,15 @@ export class Pages extends Component {
           </div>
           <strong className="message">{message}</strong>
           <div className="side-unit pull-right">
-            <InputSearch searchByTitle={searchByTitle} />
+            <InputSearch searchBy="filename" search={search} />
           </div>
         </div>
-        <div className="content-table">
-          <table>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th className="th-actions">Actions</th>
-              </tr>
-            </thead>
-            <tbody>{this.renderRows()}</tbody>
-          </table>
-        </div>
+        {
+          pages.length > 0 && this.renderTable()
+        }
+        {
+          !pages.length && <h1>{`You don't have any pages.`}</h1>
+        }
       </div>
     );
   }
@@ -100,13 +111,13 @@ Pages.propTypes = {
   deletePage: PropTypes.func.isRequired,
   isFetching: PropTypes.bool.isRequired,
   message: PropTypes.string.isRequired,
-  searchByTitle: PropTypes.func.isRequired
+  search: PropTypes.func.isRequired
 };
 
 function mapStateToProps(state) {
   const { pages, utils } = state;
   return {
-    pages: filterByTitle(pages.pages, utils.input),
+    pages: filterByFilename(pages.pages, utils.input),
     isFetching: pages.isFetching,
     message: pages.message
   };
@@ -116,7 +127,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({
     fetchPages,
     deletePage,
-    searchByTitle
+    search
   }, dispatch);
 }
 

--- a/lib/jekyll-admin/public/src/containers/views/tests/documents.spec.js
+++ b/lib/jekyll-admin/public/src/containers/views/tests/documents.spec.js
@@ -10,7 +10,7 @@ function setup(currentDocuments=[doc]) {
   const actions = {
     fetchDocuments: expect.createSpy(),
     deleteDocument: expect.createSpy(),
-    searchByTitle: expect.createSpy()
+    search: expect.createSpy()
   };
 
   let component = mount(
@@ -26,7 +26,8 @@ function setup(currentDocuments=[doc]) {
     component: component,
     actions: actions,
     h1: component.find('h1').last(),
-    message: component.find('.message')
+    message: component.find('.message'),
+    table: component.find('.content-table')
   };
 }
 
@@ -37,9 +38,10 @@ describe('Containers::Documents', () => {
     expect(message.text()).toBe('');
   });
 
-  it('should render no-docs-header when no docs provided', () => {
-    const { component, h1 } = setup([]);
+  it('should render correctly when there are not any documents', () => {
+    const { component, table, h1 } = setup([]);
     const compProps = component.props();
+    expect(table.node).toNotExist();
     expect(h1.text()).toBe(`You don't have any documents.`);
   });
 

--- a/lib/jekyll-admin/public/src/containers/views/tests/documents.spec.js
+++ b/lib/jekyll-admin/public/src/containers/views/tests/documents.spec.js
@@ -25,7 +25,7 @@ function setup(currentDocuments=[doc]) {
   return {
     component: component,
     actions: actions,
-    h1: component.find('h1'),
+    h1: component.find('h1').last(),
     message: component.find('.message')
   };
 }
@@ -40,7 +40,7 @@ describe('Containers::Documents', () => {
   it('should render no-docs-header when no docs provided', () => {
     const { component, h1 } = setup([]);
     const compProps = component.props();
-    expect(h1.text()).toBe(`You don't have any documents for this collection.`);
+    expect(h1.text()).toBe(`You don't have any documents.`);
   });
 
   it('should call fetchDocuments action after mounted', () => {

--- a/lib/jekyll-admin/public/src/containers/views/tests/pages.spec.js
+++ b/lib/jekyll-admin/public/src/containers/views/tests/pages.spec.js
@@ -23,7 +23,7 @@ function setup(pages=[page]) {
   return {
     component: component,
     actions: actions,
-    h1: component.find('h1'),
+    h1: component.find('h1').last(),
     message: component.find('.message')
   };
 }

--- a/lib/jekyll-admin/public/src/containers/views/tests/pages.spec.js
+++ b/lib/jekyll-admin/public/src/containers/views/tests/pages.spec.js
@@ -9,7 +9,7 @@ function setup(pages=[page]) {
   const actions = {
     fetchPages: expect.createSpy(),
     deletePage: expect.createSpy(),
-    searchByTitle: expect.createSpy()
+    search: expect.createSpy()
   };
 
   let component = mount(
@@ -24,7 +24,8 @@ function setup(pages=[page]) {
     component: component,
     actions: actions,
     h1: component.find('h1').last(),
-    message: component.find('.message')
+    message: component.find('.message'),
+    table: component.find('.content-table')
   };
 }
 
@@ -35,9 +36,10 @@ describe('Containers::Pages', () => {
     expect(message.text()).toBe('');
   });
 
-  it('should render no-pages-header when no docs provided', () => {
-    const { component, h1 } = setup([]);
+  it('should render correctly when there are not any pages', () => {
+    const { component, table, h1 } = setup([]);
     const compProps = component.props();
+    expect(table.node).toNotExist();
     expect(h1.text()).toBe(`You don't have any pages.`);
   });
 

--- a/lib/jekyll-admin/public/src/reducers/collections.js
+++ b/lib/jekyll-admin/public/src/reducers/collections.js
@@ -81,3 +81,13 @@ export default function collections(state = {
       });
   }
 }
+
+// Selectors
+export const filterByTitle = (list, input) => {
+  if (input) {
+    return list.filter(
+      p => p.title.toLowerCase().indexOf(input.toLowerCase()) > -1
+    );
+  }
+  return list;
+};

--- a/lib/jekyll-admin/public/src/reducers/pages.js
+++ b/lib/jekyll-admin/public/src/reducers/pages.js
@@ -66,3 +66,13 @@ export default function pages(state = {
       });
   }
 }
+
+// Selectors
+export const filterByFilename = (list, input) => {
+  if (input) {
+    return list.filter(
+      p => p.name.toLowerCase().indexOf(input.toLowerCase()) > -1
+    );
+  }
+  return list;
+};

--- a/lib/jekyll-admin/public/src/reducers/tests/fixtures/index.js
+++ b/lib/jekyll-admin/public/src/reducers/tests/fixtures/index.js
@@ -55,24 +55,18 @@ export const page = {
 
 export const pages = [
   {
-    "name": "about",
-    "content": "This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)",
-    "layout": "page",
-    "title": "About page",
+    "name": "about.md",
+    "raw_content": "# Test",
     "path": "about.md"
   },
   {
-    "name": "gsoc",
-    "content": "This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)",
-    "layout": "page",
-    "title": "GSoC",
+    "name": "gsoc.md",
+    "raw_content": "# Test",
     "path": "gsoc.md"
   },
   {
-    "name": "contact",
-    "content": "This is the base Jekyll theme.",
-    "layout": "page",
-    "title": "Contact Page",
+    "name": "contact.md",
+    "raw_content": "# Test",
     "path": "contact.md"
   }
 ];

--- a/lib/jekyll-admin/public/src/reducers/tests/utils.spec.js
+++ b/lib/jekyll-admin/public/src/reducers/tests/utils.spec.js
@@ -1,5 +1,6 @@
 import expect from 'expect';
-import reducer, { filterByTitle } from '../utils';
+import reducer from '../utils';
+import { filterByFilename } from '../pages';
 import * as types from '../../constants/actionTypes';
 
 import { pages } from './fixtures';
@@ -12,7 +13,7 @@ describe('Reducers::Utils', () => {
     });
   });
 
-  it('should handle searchByTitle', () => {
+  it('should handle search', () => {
     expect(
       reducer({}, {
         type: types.SEARCH_CONTENT,
@@ -24,7 +25,7 @@ describe('Reducers::Utils', () => {
   });
 
   it('should filter pages', () => {
-    expect(filterByTitle(pages, 'page').length).toBe(2);
+    expect(filterByFilename(pages, 'gsoc').length).toBe(1);
   });
 
   it('should validate form', () => {

--- a/lib/jekyll-admin/public/src/reducers/utils.js
+++ b/lib/jekyll-admin/public/src/reducers/utils.js
@@ -27,13 +27,3 @@ export default function utils(state = {
       });
   }
 }
-
-// Selectors
-export const filterByTitle = (list, input) => {
-  if (input) {
-    return list.filter(
-      p => p.title.toLowerCase().indexOf(input.toLowerCase()) > -1
-    );
-  }
-  return list;
-};


### PR DESCRIPTION
Fixes #100 

Additionally, I made the search mechanism more generic. Now every reducer implements their own filter selector rather using the one in utility reducer. In this way, they can choose the field to be filtered by. This will allow us to search static and data files by filename.