### PR TITLE
Data files should default to `.yml` extension

### DIFF
--- a/lib/jekyll-admin/server/data.rb
+++ b/lib/jekyll-admin/server/data.rb
@@ -1,5 +1,8 @@
 module JekyllAdmin
   class Server < Sinatra::Base
+    # supported extensions, in order of preference, for now, no .csv
+    EXTENSIONS = %w(yml json).freeze
+
     namespace "/data" do
       get do
         json data_files.to_liquid
@@ -30,15 +33,40 @@ module JekyllAdmin
       end
 
       def data_file
-        data_files[params["data_file_id"]]
+        data_files[data_file_key]
+      end
+
+      # Data file without extension, as used in site.data[keys]
+      def data_file_key
+        File.basename params["data_file_id"], ".*"
       end
 
       def ensure_data_file_exists
         render_404 if data_file.nil?
       end
 
+      # site.data returns hashes, not objects, so we need to be creative here
+      # and figure out the data file's appropriate extension, defaulting to yml
+      #
+      # If the client passes an extention, we'll honor that. Otherwise,
+      # this method checks for data files matching the given ID, in order of
+      # the extension preference in the EXTENSIONS constant, and returns the
+      # first match, defaulting to YML if none exists.
       def data_file_path
-        sanitized_path "_data/#{params["data_file_id"]}.yml"
+        extension = File.extname(params["data_file_id"])
+        base_path = File.join site.config["data_dir"], params["data_file_id"]
+
+        if extension.empty?
+          # default to yml as a fallback if no other is found
+          extension = EXTENSIONS.first
+          EXTENSIONS.each do |ext|
+            path = "#{base_path}.#{ext}"
+            path = sanitized_path("#{path}.#{ext}")
+            return path if File.exist?(path)
+          end
+        end
+
+        sanitized_path "#{base_path}.#{extension}"
       end
 
       def data_file_body

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -17,6 +17,12 @@ describe "data" do
     expect(last_response_parsed).to eql({ "foo" => "bar" })
   end
 
+  it "gets an individual data file with an extension" do
+    get "/data/data_file.yml"
+    expect(last_response).to be_ok
+    expect(last_response_parsed).to eql({ "foo" => "bar" })
+  end
+
   it "writes a new data file" do
     delete_file "_data/data-file-new.yml"
 


### PR DESCRIPTION
This pull request makes it so requests to `/data/*` in the API default to the `.yml` extension, when none is given, but also supports accepting an explicit extension.

For now, you can `GET` and `DELETE` files with a `.json` extension. I've opened https://github.com/jekyll/jekyll-admin/issues/106 to track writing JSON data files, but that's not critical for an initial release / GSoC in my mind.

Fixes https://github.com/jekyll/jekyll-admin/issues/104