### PR TITLE
Update static file API to expect base64 encoded files

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Data files and the config file are direct JSON representations of the underlying
 
 #### Static files
 
-Static files are just the raw content and may be binary.
+Static files are non-Jekyll files and may be binary or text.
 
 ### Collections
 
@@ -124,11 +124,28 @@ File will be written to disk in YAML. It will not necessarily to preserve whites
 
 ### Static files
 
+#### Parameters
+
 * `path` - the path to the file or directory, relative to the site root (`String`)
+* `raw_content` - The raw, text-based content to be written directly to disk (`String`)
+* `encoded_content` - The Base64 encoded text or binary content (`String`)
+
+### Example response
+
+```json
+{
+  "extname": ".txt",
+  "modified_time": "2016-08-10 18:05:45 -0400",
+  "path": "/test.txt",
+  "encoded_content": "dGVzdA==\n"
+}
+```
+
+**Note**: The `encoded_content` field is the Base64 encoded representation of the file's content.
 
 #### `GET /static_files/:path`
 
-Returns the requested static file. The response does not include the file's content.
+Returns the requested static file.
 
 If the path maps to a directory, it list all static files in the directory. This does not include documents, pages, etc.
 

--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -6,6 +6,7 @@ ENV["RACK_ENV"] = "production" if ENV["RACK_ENV"].to_s.empty?
 
 require "json"
 require "jekyll"
+require "base64"
 require "webrick"
 require "sinatra"
 require "fileutils"
@@ -27,7 +28,7 @@ require "jekyll-admin/apiable.rb"
 
 # Monkey Patches
 require_relative "./jekyll/commands/serve"
-[Jekyll::Page, Jekyll::Document].each do |klass|
+[Jekyll::Page, Jekyll::Document, Jekyll::StaticFile].each do |klass|
   klass.include JekyllAdmin::APIable
 end
 

--- a/spec/jekyll-admin/static_file_spec.rb
+++ b/spec/jekyll-admin/static_file_spec.rb
@@ -16,6 +16,7 @@ describe "static_files" do
     expect(last_response).to be_ok
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-file.txt")
+    expect(last_response_parsed["encoded_content"]).to eql("VEVTVAo=\n")
   end
 
   it "404s when a static file doesn't exist" do
@@ -61,12 +62,28 @@ describe "static_files" do
   it "writes a static file" do
     delete_file "static-file-new.txt", "test"
 
-    request = { :body => "test" }
+    request = { :encoded_content => "dGVzdA==" }
     put "/static_files/static-file-new.txt", request.to_json
 
     expect(last_response).to be_ok
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-file-new.txt")
+    expect(last_response_parsed["encoded_content"]).to eql("dGVzdA==\n")
+    expect("static-file-new.txt").to be_an_existing_file
+
+    delete_file "static-file-new.txt"
+  end
+
+  it "writes a static file with raw content" do
+    delete_file "static-file-new.txt", "test"
+
+    request = { :raw_content => "test" }
+    put "/static_files/static-file-new.txt", request.to_json
+
+    expect(last_response).to be_ok
+    expect(last_response_parsed["extname"]).to eql(".txt")
+    expect(last_response_parsed["path"]).to eql("/static-file-new.txt")
+    expect(last_response_parsed["encoded_content"]).to eql("dGVzdA==\n")
     expect("static-file-new.txt").to be_an_existing_file
 
     delete_file "static-file-new.txt"
@@ -75,12 +92,13 @@ describe "static_files" do
   it "deeply writes a static file" do
     delete_file "static-dir/file-new.txt"
 
-    request = { :body => "test" }
+    request = { :encoded_content => "dGVzdA==" }
     put "/static_files/static-dir/file-new.txt", request.to_json
 
     expect(last_response).to be_ok
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-dir/file-new.txt")
+    expect(last_response_parsed["encoded_content"]).to eql("dGVzdA==\n")
     expect("static-dir/file-new.txt").to be_an_existing_file
 
     delete_file "static-dir/file-new.txt"
@@ -89,12 +107,13 @@ describe "static_files" do
   it "updates a static file" do
     write_file "static-file-update.txt", "test2"
 
-    request = { :body => "test" }
+    request = { :encoded_content => "dGVzdDI=" }
     put "/static_files/static-file-update.txt", request.to_json
 
     expect(last_response).to be_ok
     expect(last_response_parsed["extname"]).to eql(".txt")
     expect(last_response_parsed["path"]).to eql("/static-file-update.txt")
+    expect(last_response_parsed["encoded_content"]).to eql("dGVzdDI=\n")
     expect("static-file-update.txt").to be_an_existing_file
     delete_file "static-file-update.txt"
   end


### PR DESCRIPTION
This design pattern is based off [the GitHub Content API](https://developer.github.com/v3/repos/contents/#create-a-file) and expects that raw files will be submitted as base64 encoded strings, and returned as the same to get around binary and encoding issues.

Request payloads may now submit `raw_content` or `encoded_content` fields, both of which will be written to disk (with `encoded_content` being base64 decoded first). You can always use `encoded_content`, but could use `raw_content` for content which you were confident did not have any potential encoding issues that might break JSON.

The file is always returned with the `encoded_content` field, and will not have `content`, `raw_content` or `front_matter`.