### PR TITLE
fix link to development docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll
 
 ## Development
 
-See [the development docs](development/)
+See [the development docs](http://jekyll.github.io/jekyll-admin/development/)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll
 
 ## Development
 
-See [the development docs](/docs)
+See [the development docs](development/)
 
 ## License
 


### PR DESCRIPTION
Don't know if you prefer to have a valid link on Github or locally on Jekyll ? 