### PR TITLE
Include compiled front end in built gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 /spec/fixtures/site/Gemfile.lock
 node_modules
 /lib/jekyll-admin/public
+*.gem

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|spec|src|tools|script|docs)/}) }
+  spec.files         = Dir.glob("lib/**/*").concat(%w(LICENSE README.md))
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|spec|src|tools|script|docs)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The default gemspec uses Git to determine what files to include in the build Gem, but we're .gitignore-ing the built site.

This PR updates the Gemspec to include all files in the `lib` directory, plus the LICENSE and README in the built gem when distributed. Here's what it looks like:

![screen shot 2016-08-18 at 2 21 55 pm](https://cloud.githubusercontent.com/assets/282759/17785528/3469048a-654f-11e6-9ce9-0631d4bcfdbe.png)
