### PR TITLE
Load static files directly from Jekyll server

### DIFF
--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -15,11 +15,15 @@ export default class FilePreview extends Component {
     const { file } = this.props;
     const extension = file.extname.substring(1);
     const image = /png|jpg|gif|jpeg/.test(extension);
+    let prefix = '';
+    if (process.env.NODE_ENV == 'development') {
+      prefix = 'http://localhost:4000';
+    }
     return (
       <div className="file-preview">
-        <a href={file.path} target="_blank">
+        <a href={prefix+file.path} target="_blank">
         {
-          image && <img src={`data:image/${extension};base64,${file.encoded_content}`} />
+          image && <img src={prefix+file.path} />
         }
         {
           !image &&


### PR DESCRIPTION
Front-end was using `encoded_content` for previewing static files. Since it only lists all of the static files and index API responses include file contents, there was no need to call individual endpoints. With #138 , file contents will be removed from all indexes so `encoded_content` will not be available for index API. With this PR, front-end loads static files directly from Jekyll server using `path` field without needing the actual contents.