### PR TITLE
Exclude next/previous contents from indexes

### DIFF
--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -2,6 +2,9 @@ module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, API-specific functionality without duplicating logic
   module APIable
+
+    CONTENT_FIELDS = %w(next previous content excerpt).freeze
+
     # Returns a hash suitable for use as an API response.
     #
     # For Documents and Pages:
@@ -13,26 +16,19 @@ module JekyllAdmin
     #
     # Options:
     #
-    # content - if true, includes the content in the respond, false by default
-    #           to support mapping on indexes where we only want metadata
+    # include_content - if true, includes the content in the respond, false by default
+    #                   to support mapping on indexes where we only want metadata
     #
     # Returns a hash (which can then be to_json'd)
     def to_api(include_content: false)
-      output = to_liquid.to_h
+      output = hash_for_api
 
-      if include_content && File.exist?(file_path)
-        if is_a?(Jekyll::StaticFile)
-          output["encoded_content"] = encoded_content
-        elsif is_a?(JekyllAdmin::DataFile)
-          output["content"] = content
-          output["raw_content"] = raw_content
-        else
-          output["raw_content"] = raw_content
-          output["front_matter"] = front_matter
-        end
+      # Include content, if requested, otherwise remove it
+      if include_content
+        output = output.merge(content_fields)
+      else
+        CONTENT_FIELDS.each { |field| output.delete(field) }
       end
-
-      output.delete("content") unless include_content
 
       # Documents have duplicate output and content fields, Pages do not
       # Since it's an API, use `content` in both for consistency
@@ -91,6 +87,44 @@ module JekyllAdmin
 
     def encoded_content
       @encoded_content ||= Base64.encode64(file_contents)
+    end
+
+    # Base hash from which to generate the API output
+    def hash_for_api
+      output = to_liquid
+      if output.respond_to?(:hash_for_json)
+        output.hash_for_json
+      else
+        output.to_h
+      end
+    end
+
+    # Returns a hash of content fields for inclusion in the API output
+    def content_fields
+      output = {}
+
+      if File.exist?(file_path)
+        if is_a?(Jekyll::StaticFile)
+          output["encoded_content"] = encoded_content
+        elsif is_a?(JekyllAdmin::DataFile)
+          output["content"] = content
+          output["raw_content"] = raw_content
+        else
+          output["raw_content"] = raw_content
+          output["front_matter"] = front_matter
+        end
+      end
+
+      # Include next and previous documents non-recursively
+      if is_a?(Jekyll::Document)
+        %w(next previous).each do |direction|
+          method = "#{direction}_doc".to_sym
+          doc = public_send(method)
+          output[direction] = doc.to_api if doc
+        end
+      end
+
+      output
     end
   end
 end

--- a/lib/jekyll-admin/version.rb
+++ b/lib/jekyll-admin/version.rb
@@ -1,3 +1,3 @@
 module JekyllAdmin
-  VERSION = "0.1.0.pre3b".freeze
+  VERSION = "0.1.0.pre2".freeze
 end

--- a/lib/jekyll-admin/version.rb
+++ b/lib/jekyll-admin/version.rb
@@ -1,3 +1,3 @@
 module JekyllAdmin
-  VERSION = "0.1.0.pre2".freeze
+  VERSION = "0.1.0.pre3b".freeze
 end

--- a/spec/fixtures/site/_posts/2016-02-01-test.md
+++ b/spec/fixtures/site/_posts/2016-02-01-test.md
@@ -1,0 +1,5 @@
+---
+foo: bar
+---
+
+# Test Post2

--- a/spec/fixtures/site/_posts/2016-03-01-test.md
+++ b/spec/fixtures/site/_posts/2016-03-01-test.md
@@ -1,0 +1,5 @@
+---
+foo: bar
+---
+
+# Test Post3

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -45,12 +45,19 @@ describe "collections" do
       expect(last_response_parsed.first).to_not have_key("front_matter")
     end
 
-    it "deoesn't include content in the index" do
+    it "doesn't include content in the index" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
       expect(last_response_parsed.first).to_not have_key("content")
       expect(last_response_parsed.first).to_not have_key("raw_content")
       expect(last_response_parsed.first).to_not have_key("output")
+    end
+
+    it "doesn't include next/previous in the index" do
+      get "/collections/posts/documents"
+      expect(last_response).to be_ok
+      expect(last_response_parsed.first).to_not have_key("next")
+      expect(last_response_parsed.first).to_not have_key("previous")
     end
   end
 
@@ -89,6 +96,25 @@ describe "collections" do
       get "/collections/posts/2016-01-01-test.md"
       expect(last_response).to be_ok
       expect(last_response_parsed["raw_content"]).to eq("# Test Post\n")
+    end
+
+    %w(next previous).each do |direction|
+      it "includes the #{direction} document non-recursively" do
+        get "/collections/posts/2016-02-01-test.md"
+        expect(last_response).to be_ok
+        expect(last_response_parsed).to have_key(direction)
+        expect(last_response_parsed[direction]).to_not have_key("next")
+        expect(last_response_parsed[direction]).to_not have_key("previous")
+      end
+
+      it "doesn't include the #{direction} document's content" do
+        get "/collections/posts/2016-02-01-test.md"
+        expect(last_response).to be_ok
+        expect(last_response_parsed).to have_key(direction)
+        expect(last_response_parsed[direction]).to_not have_key("content")
+        expect(last_response_parsed[direction]).to_not have_key("raw_content")
+        expect(last_response_parsed[direction]).to_not have_key("output")
+      end
     end
 
     context "front matter" do


### PR DESCRIPTION
A follow up to https://github.com/jekyll/jekyll-admin/pull/138, #138 removed the `content` fields from documents when retrieving an index... but we still included the content of the next/previous document, and did so recursively. 

So while the document itself had no content, for each document we loaded, we loaded up to four document's contents in the next/previous fields.

This PR updates the `to_api` logic to not include the content of nor the next/previous document for other documents when generating a given document's next/previous fields.

### Before

```json
{
  "path": "whatever",
  "next" {
    "path": "something",
    "content": "foo",
    "next": { 
     ...
    } 
    ...
  }
}
```

### After

```json
{
  "path": "whatever",
  "next" {
    "path": "something"
    ...
  }
  ...
}
```

I don't believe next/previous was used by the front end, and thus no front end change should be necessary. This does however, make document lists load significantly faster on large sites.