### PR TITLE
Added date to breadcrumb input default value/placeholder

### DIFF
--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import _ from 'underscore';
+import moment from 'moment';
 
 import { toTitleCase } from '../utils/helpers';
 
@@ -14,8 +15,12 @@ export default class Breadcrumbs extends Component {
   render() {
     const { link, type, path } = this.props;
     let placeholder = 'example.md';
+    let value = '';
+
     if (type == 'posts') {
-      placeholder = '2016-01-07-your-title.md';
+      const date = moment().format('YYYY-MM-DD');
+      value = date + '-your-title.md';
+      placeholder = date + '-your-title.md';
     }else if (type == 'data files') {
       placeholder = 'your-filename.yml';
     }
@@ -26,7 +31,7 @@ export default class Breadcrumbs extends Component {
           <input onChange={(e) => this.handleChange(e)}
             ref="input"
             placeholder={placeholder}
-            defaultValue={path || ''} />
+            defaultValue={path || value} />
         </li>
       </ul>
     );

--- a/src/components/tests/breadcrumbs.spec.js
+++ b/src/components/tests/breadcrumbs.spec.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import expect from 'expect';
 import { mount } from 'enzyme';
 import { capitalize } from '../../utils/helpers';
-
+import moment from 'moment';
 import Breadcrumbs from '../Breadcrumbs';
 
 import { content } from './fixtures';
@@ -40,6 +40,12 @@ describe('Components::Breadcrumbs', () => {
       link.first().prop('children')
     ).toBe(capitalize(content.collection));
     expect(input.prop('defaultValue')).toBe(content.path);
+  });
+  it('should prepend date to input value/placeholder for new post', () => {
+    const { component, link, li, input } = setup({ link:'test', collection:'posts', path:'' });
+    const expectedValue = moment().format('YYYY-MM-DD') + '-your-title.md';
+    expect(input.prop('defaultValue')).toBe(expectedValue);
+    expect(input.prop('placeholder')).toBe(expectedValue);
   });
   it('should call onChange', () => {
     const { input, actions } = setup();

--- a/src/components/tests/breadcrumbs.spec.js
+++ b/src/components/tests/breadcrumbs.spec.js
@@ -42,7 +42,7 @@ describe('Components::Breadcrumbs', () => {
     expect(input.prop('defaultValue')).toBe(content.path);
   });
   it('should prepend date to input value/placeholder for new post', () => {
-    const { component, link, li, input } = setup({ link:'test', collection:'posts', path:'' });
+    const { input } = setup({ link:'test', collection:'posts', path:'' });
     const expectedValue = moment().format('YYYY-MM-DD') + '-your-title.md';
     expect(input.prop('defaultValue')).toBe(expectedValue);
     expect(input.prop('placeholder')).toBe(expectedValue);


### PR DESCRIPTION
This is a new clean version of the #148 PR, with tests included.

Sets a "YYYY-MM-DD-your-title.md" default value to breadcrumb input and placeholder when the collection is 'posts'.