### PR TITLE
Added inactive state class to save button

### DIFF
--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -25,7 +25,7 @@ export class Configuration extends Component {
         <div className="content-header">
           <h1>Configuration</h1>
           <div className="page-buttons">
-            <a className={"btn " + (editorChanged ? 'btn-active':'')}
+            <a className={"btn " + (editorChanged ? 'btn-active':' btn-inactive ')}
               onClick={() => this.handleSaveClick()}>
                 {updated ? 'Saved' : 'Save'}
             </a>

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -25,7 +25,7 @@ export class Configuration extends Component {
         <div className="content-header">
           <h1>Configuration</h1>
           <div className="page-buttons">
-            <a className={"btn " + (editorChanged ? 'btn-active':' btn-inactive ')}
+            <a className={"btn " + (editorChanged ? 'btn-active':'btn-inactive')}
               onClick={() => this.handleSaveClick()}>
                 {updated ? 'Saved' : 'Save'}
             </a>

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -84,7 +84,7 @@ export class DataFileEdit extends Component {
 
           <div className="content-side">
             <a onClick={() => this.handleClickSave()}
-              className={"btn"+(datafileChanged ? " btn-success " : " ")+"btn-fat"}>
+              className={"btn"+(datafileChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
               {updated ? 'Saved' : 'Save'}
             </a>
             <Splitter />

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -67,7 +67,7 @@ export class DataFileNew extends Component {
           <div className="content-side">
             <div className="side-unit">
               <a onClick={() => this.handleClickSave()}
-                className={"btn"+(datafileChanged ? " btn-success " : " ")+"btn-fat"}>
+                className={"btn"+(datafileChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
                 {updated ? 'Saved' : 'Save'}
               </a>
             </div>

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -97,7 +97,7 @@ export class DocumentEdit extends Component {
           <div className="content-side">
             <div className="side-unit">
               <a onClick={() => this.handleClickSave(filename, collection)}
-                className={"btn"+(fieldChanged ? " btn-success " : " ")+"btn-fat"}>
+                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
                 {updated ? 'Saved' : 'Save'}
               </a>
             </div>

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -85,7 +85,7 @@ export class DocumentNew extends Component {
           <div className="content-side">
             <div className="side-unit">
               <a onClick={() => this.handleClickSave()}
-                className={"btn"+(fieldChanged ? " btn-success " : " ")+"btn-fat"}>
+                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
                 {updated ? 'Created' : 'Create'}
               </a>
             </div>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -92,7 +92,7 @@ export class PageEdit extends Component {
           <div className="content-side">
             <div className="side-unit">
               <a onClick={() => this.handleClickSave(name)}
-                className={"btn"+(fieldChanged ? " btn-success " : " ")+"btn-fat"}>
+                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
                 {updated ? 'Saved' : 'Save'}
               </a>
             </div>

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -77,7 +77,7 @@ export class PageNew extends Component {
           <div className="content-side">
             <div className="side-unit">
               <a onClick={() => this.handleClickSave()}
-                className={"btn"+(fieldChanged ? " btn-success " : " ")+"btn-fat"}>
+                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
                 {updated ? 'Created' : 'Create'}
               </a>
             </div>

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -30,7 +30,7 @@ describe('Containers::Configuration', () => {
   it('should render correctly with initial props', () => {
     const { component, editor, saveButton } = setup();
     expect(saveButton.text()).toBe('Save');
-    expect(saveButton.prop('className').trim()).toBe('btn');
+    expect(saveButton.prop('className').trim()).toBe('btn btn-inactive');
     expect(editor.prop('json')).toEqual(config);
   });
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -77,6 +77,10 @@ i {
   @include btn($btn-active, $btn-active-border);
 }
 
+.btn-inactive {
+  @include btn($btn-inactive, $btn-inactive-border, default, .4, false); 
+}
+
 .btn-success {
   @include btn($btn-success, $btn-success-border);
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -78,7 +78,7 @@ i {
 }
 
 .btn-inactive {
-  @include btn($btn-inactive, $btn-inactive-border, default, .4, false); 
+  @include btn($btn-inactive, $btn-inactive-border, default, .5, false); 
 }
 
 .btn-success {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -48,12 +48,18 @@
   transform: translateX($px);
 }
 
-@mixin btn($color, $border-color) {
+@mixin btn($color, $border-color, $cursor: pointer, $opacity: 1, $hover: true) {
+  cursor: $cursor!important;
+  opacity: $opacity;
   background-color: $color;
   @include box-shadow(0 1px 0 $border-color);
-  &:hover {
-    background-color: darken($color, 5%);
-  }
+    &:hover {
+      @if ($hover) {
+        background-color: darken($color, 5%);
+      } @else {
+        background-color: $color;
+      }
+    }
 }
 
 @mixin nodrag() {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -13,6 +13,8 @@ $btn-initial: #b9b9b9;
 $btn-initial-border: #828282;
 $btn-active: #ff6e00;
 $btn-active-border: #dd5c00;
+$btn-inactive: $btn-initial;
+$btn-inactive-border: $btn-initial-border;
 $btn-success: #8dcf3f;
 $btn-success-border: #6ba329;
 $btn-danger: #ff6868;


### PR DESCRIPTION
This adds a 'btn-inactive' class to all save buttons on inactive state. I believe the inactive state isn't really straightforward to the user right now, and having an inactive class that can be used anytime is a plus imo :)

Changed the mixin to accept more parameters with default values like  $cursor: pointer, $opacity: 1, $hover: true in order to avoid losing consistency. 

Hope you like it :smiley_cat: