### PR TITLE
Update package to allow running script on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start-message": "babel-node tools/startMessage.js",
     "prestart": "npm-run-all --parallel start-message remove-dist",
     "start": "npm-run-all --parallel start-api test:watch open:src lint:watch",
-    "start-api": "script/test-server",
+    "start-api": "sh script/test-server",
     "open:src": "babel-node tools/srcServer.js",
     "lint": "esw webpack.config.* src tools",
     "lint:watch": "npm run lint -- --watch",


### PR DESCRIPTION
I had trouble running `script/server-frontend` as `script/test-server` call further ahead would not run out-of-the-box on Windows.
```
'script' is not recognized as an internal or external command,
operable program or batch file.
```
Hence prepended a `sh`.