### PR TITLE
Expose documents on collection index

### DIFF
--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -19,8 +19,10 @@ module JekyllAdmin
     # include_content - if true, includes the content in the respond, false by default
     #                   to support mapping on indexes where we only want metadata
     #
+    # include_documents - for collections, whether to output the collection's documents
+    #
     # Returns a hash (which can then be to_json'd)
-    def to_api(include_content: false)
+    def to_api(include_content: false, include_documents: false)
       output = hash_for_api
       output = output.merge(url_fields)
 
@@ -36,8 +38,12 @@ module JekyllAdmin
       output.delete("output")
 
       # By default, calling to_liquid on a collection will return a docs
-      # array with each rendered document, which we don't want
-      output.delete("docs") if is_a?(Jekyll::Collection)
+      # array with each rendered document, which we don't want. Instead
+      # include our own documents array, without the content
+      if is_a?(Jekyll::Collection)
+        output.delete("docs")
+        output["documents"] = docs.map(&:to_api) if include_documents
+      end
 
       output
     end

--- a/lib/jekyll-admin/server/collection.rb
+++ b/lib/jekyll-admin/server/collection.rb
@@ -7,11 +7,13 @@ module JekyllAdmin
 
       get "/:collection_id" do
         ensure_collection
-        json collection.to_api
+        json collection.to_api(:include_documents => true)
       end
 
       get "/:collection_id/documents" do
         ensure_collection
+        msg = "The `documents` endpoint is deprecated and may be removed at any time."
+        Jekyll::Deprecator.deprecation_message msg
         json collection.docs.map(&:to_api)
       end
 

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -13,51 +13,84 @@ describe "collections" do
     JekyllAdmin.site.process
   end
 
-  it "returns the collection index" do
-    get "/collections"
-    expect(last_response).to be_ok
-    expect(last_response_parsed.first["label"]).to eq("posts")
-    expect(last_response_parsed.first["content"]).to be_nil
+  let(:first_response) { last_response_parsed.first }
+
+  context "collection index" do
+    it "returns the collection index" do
+      get "/collections"
+      expect(last_response).to be_ok
+      expect(first_response["label"]).to eq("posts")
+      expect(first_response["content"]).to be_nil
+    end
+
+    it "doesn't include documents" do
+      get "/collections"
+      expect(last_response).to be_ok
+      expect(first_response).to_not have_key("documents")
+      expect(first_response).to_not have_key("docs")
+    end
   end
 
-  it "returns an individual collection" do
-    get "/collections/posts"
-    expect(last_response).to be_ok
-    expect(last_response_parsed["label"]).to eq("posts")
+  context "an individual collection" do
+    let(:documents) { last_response_parsed["documents"] }
+    let(:first_document) { documents.first }
+
+    it "returns an individual collection" do
+      get "/collections/posts"
+      expect(last_response).to be_ok
+      expect(last_response_parsed["label"]).to eq("posts")
+    end
+
+    it "includes documents" do
+      get "/collections/posts"
+      expect(last_response).to be_ok
+      expect(last_response_parsed).to_not have_key("docs")
+      expect(last_response_parsed).to have_key("documents")
+
+      expect(documents.count).to eql(3)
+      expect(first_document["title"]).to eql("Test")
+    end
+
+    it "doesn't include document content" do
+      get "/collections/posts"
+      expect(last_response).to be_ok
+      expect(first_document).to_not have_key("raw_content")
+      expect(first_document).to_not have_key("content")
+    end
   end
 
   context "document index" do
     it "returns collection documents" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first["title"]).to eq("Test")
+      expect(first_response["title"]).to eq("Test")
     end
 
     it "includes front matter defaults" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first.key?("some_front_matter")).to eq(true)
+      expect(first_response.key?("some_front_matter")).to eq(true)
     end
 
     it "doesn't include the raw front matter" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first).to_not have_key("front_matter")
+      expect(first_response).to_not have_key("front_matter")
     end
 
     it "doesn't include content in the index" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first).to_not have_key("content")
-      expect(last_response_parsed.first).to_not have_key("raw_content")
-      expect(last_response_parsed.first).to_not have_key("output")
+      expect(first_response).to_not have_key("content")
+      expect(first_response).to_not have_key("raw_content")
+      expect(first_response).to_not have_key("output")
     end
 
     it "doesn't include next/previous in the index" do
       get "/collections/posts/documents"
       expect(last_response).to be_ok
-      expect(last_response_parsed.first).to_not have_key("next")
-      expect(last_response_parsed.first).to_not have_key("previous")
+      expect(first_response).to_not have_key("next")
+      expect(first_response).to_not have_key("previous")
     end
   end
 


### PR DESCRIPTION
This PR deprecates the `collections/collection/documents/` endpoint, and creates a new `documents` key on for the collections endpoint.

The idea being, because individual documents are `collections/collection/path`, the `collections/collection/documents/` endpoint breaks RESTful semantics.

Here's what it'd look like in practice:

GET `_api/collections`

```json
[
   {
      "label":"posts",
      "files":[

      ],
      "directory":"/Users/benbalter/github/jekyll-admin/spec/fixtures/site/_posts",
      "relative_directory":"_posts",
      "permalink":"/:categories/:year/:month/:day/:title:output_ext",
      "http_url":null,
      "api_url":"http://localhost:4000/_api/collections/posts"
   },
   {
      "label":"puppies",
      "files":[

      ],
      "directory":"/Users/benbalter/github/jekyll-admin/spec/fixtures/site/_puppies",
      "relative_directory":"_puppies",
      "foo":"bar",
      "http_url":null,
      "api_url":"http://localhost:4000/_api/collections/puppies"
   }
]
```

GET `_api/collections/posts`

```json
{
   "label":"posts",
   "files":[

   ],
   "directory":"/Users/benbalter/github/jekyll-admin/spec/fixtures/site/_posts",
   "relative_directory":"_posts",
   "permalink":"/:categories/:year/:month/:day/:title:output_ext",
   "http_url":null,
   "api_url":"http://localhost:4000/_api/collections/posts",
   "documents":[
      {
         "path":"_posts/2016-01-01-test.md",
         "url":"/2016/01/01/test.html",
         "id":"/2016/01/01/test",
         "relative_path":"_posts/2016-01-01-test.md",
         "collection":"posts",
         "draft":false,
         "categories":[

         ],
         "some_front_matter":"default",
         "foo":"bar",
         "date":"2016-01-01 00:00:00 -0500",
         "title":"Test",
         "slug":"test",
         "ext":".md",
         "tags":[

         ],
         "http_url":"http://localhost:4000/2016/01/01/test.html",
         "api_url":"http://localhost:4000/_api/collections/posts/2016-01-01-test.md"
      },
      {
         "path":"_posts/2016-02-01-test.md",
         "url":"/2016/02/01/test.html",
         "id":"/2016/02/01/test",
         "relative_path":"_posts/2016-02-01-test.md",
         "collection":"posts",
         "draft":false,
         "categories":[

         ],
         "some_front_matter":"default",
         "foo":"bar",
         "date":"2016-02-01 00:00:00 -0500",
         "title":"Test",
         "slug":"test",
         "ext":".md",
         "tags":[

         ],
         "http_url":"http://localhost:4000/2016/02/01/test.html",
         "api_url":"http://localhost:4000/_api/collections/posts/2016-02-01-test.md"
      },
      {
         "path":"_posts/2016-03-01-test.md",
         "url":"/2016/03/01/test.html",
         "id":"/2016/03/01/test",
         "relative_path":"_posts/2016-03-01-test.md",
         "collection":"posts",
         "draft":false,
         "categories":[

         ],
         "some_front_matter":"default",
         "foo":"bar",
         "date":"2016-03-01 00:00:00 -0500",
         "title":"Test",
         "slug":"test",
         "ext":".md",
         "tags":[

         ],
         "http_url":"http://localhost:4000/2016/03/01/test.html",
         "api_url":"http://localhost:4000/_api/collections/posts/2016-03-01-test.md"
      }
   ]
}
```

Pending feedback, my suggestion would be to merge this non-breaking PR, and then update the front end to use the new endpoint in a subsequent pass.

Fixes https://github.com/jekyll/jekyll-admin/issues/172.