### PR TITLE
Add version info to sidebar

### DIFF
--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
 import _ from 'underscore';
+import { VERSION } from '../utils/version';
 
 // Constants
 import { ADMIN_PREFIX } from '../constants';
@@ -68,6 +69,10 @@ export class Sidebar extends Component {
               <Link activeClassName="active" to={`${ADMIN_PREFIX}/configuration`}><i className="fa fa-cog"></i>Configuration</Link>
             </li>
           </ul>
+        </div>
+        <div className="about_info">
+          <p className="module_name">JekyllAdmin</p>
+          <p className="module_version">VERSION: {VERSION}</p>
         </div>
       </div>
     );

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -47,11 +47,29 @@
       }
     }
   }
+  .about_info {
+    position: fixed;
+    bottom: 15px;
+    width: $sidebar-width;
+    margin: 0 auto;
+    font-weight: 900;
+    color: #1f1f1f;
+    text-align: center;
+    text-shadow: 0 1px #4d4d4d;
+    background: #333;
+    p {
+      margin: 4px 0;
+      font-size: 15px;
+      &.module_name {
+        font-size: 19px;
+      }
+    }
+  }
   .splitter {
-  height: 1px;
-  width: 100%;
-  margin: 5px 0;  
-  border-bottom: 1px solid #424242;
-  border-top: 1px solid #212121;
+    height: 1px;
+    width: 100%;
+    margin: 5px 0;  
+    border-bottom: 1px solid #424242;
+    border-top: 1px solid #212121;
   }
 }

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -1,0 +1,1 @@
+export const VERSION = '0.1.1';


### PR DESCRIPTION
This PR adds version info to the sidebar.
It doesn't solve any existing issues but simply acts as filler content at the bottom portion of the sidebar.
_To me,_ this adds a sort of visual balance.

![version-on-sidebar](https://cloud.githubusercontent.com/assets/12479464/18195800/4882493c-710b-11e6-982b-ea555ddb5e7c.png)
