### PR TITLE
update css for 'date' metafield

### DIFF
--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -256,12 +256,39 @@
   .rw-datetimepicker {
     box-shadow: none !important;
     font-size: 16px !important;
+    .rw-btn {
+      min-width: 37px;
+      i { margin: 0; }
+    }
+    &.rw-has-both {
+      padding-right: 74px;
+      > .rw-select {
+        width: 75px;
+        &:hover {
+          background: #fff;
+        }
+        .rw-btn:first-child { border-right: 1px solid #ccc; }
+        .rw-btn:hover { background: #fc0; }
+      }
+    }
   }
   .rw-calendar-popup {
     left: auto !important;
     right: -10px !important;
   }
+  .rw-calendar {
+    .rw-header {
+      padding-bottom: 15px;
+      .rw-btn-view { width: 188px; }
+    }
+  }
+  .rw-calendar-grid th {
+    padding-bottom: 8px;
+  }
   .rw-state-focus {
     border: 1px solid $dark-orange !important;
+  }
+  .rw-list-option {
+    padding: 8px 5px;
   }
 }


### PR DESCRIPTION
came across a bug in the CSS for 'react-widget' buttons. This PR addresses that issue and additional cosmetic changes to associated elements.

## Before

![dateb](https://cloud.githubusercontent.com/assets/12479464/18911992/afc0125e-859d-11e6-9d5d-ed472cf9596b.png)

--
# After

![datef](https://cloud.githubusercontent.com/assets/12479464/18912016/d5633d42-859d-11e6-902e-eb7255f0a229.png)
