### PR TITLE
Use original SimpleMDE

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "redux": "3.5.2",
     "redux-logger": "^2.6.1",
     "redux-thunk": "^2.1.0",
-    "simplemde-fork": "0.0.1",
+    "simplemde": "^1.11.2",
     "slug": "^0.9.1",
     "sortablejs": "^1.4.2",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "brace": "^0.8.0",
+    "codemirror": "^5.19.0",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.6.1",
     "lodash": "^4.13.1",

--- a/src/components/MarkdownEditor.js
+++ b/src/components/MarkdownEditor.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import SimpleMDE from 'simplemde-fork';
+import SimpleMDE from 'simplemde';
 
 const classNames = [
   'editor-toolbar',

--- a/tools/build.js
+++ b/tools/build.js
@@ -29,7 +29,7 @@ webpack(config).run((error, stats) => {
   console.log(`Webpack stats: ${stats}`);
 
   // if we got this far, the build succeeded.
-  console.log(chalkSuccess('Your app is compiled in production mode in /dist. It\'s ready to roll!'));
+  console.log(chalkSuccess('Your app is compiled in production mode in ./lib/jekyll-admin/public. It\'s ready to roll!'));
 
   return 0;
 });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -9,6 +9,7 @@ const GLOBALS = {
 
 export default {
   debug: true,
+  node: { fs: 'empty' },
   devtool: 'cheap-module-eval-source-map', // more info:https://webpack.github.io/docs/build-performance.html#sourcemaps and https://webpack.github.io/docs/configuration.html#devtool
   noInfo: true, // set to false to see a list of every file being bundled.
   entry: [
@@ -24,7 +25,8 @@ export default {
   plugins: [
     new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.htmlnew webpack.HotModuleReplacementPlugin());
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoErrorsPlugin(),
+    new webpack.ProvidePlugin({ CodeMirror: 'codemirror' })
   ],
   module: {
     loaders: [

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -25,8 +25,7 @@ export default {
   plugins: [
     new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.htmlnew webpack.HotModuleReplacementPlugin());
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
-    new webpack.ProvidePlugin({ CodeMirror: 'codemirror' })
+    new webpack.NoErrorsPlugin()
   ],
   module: {
     loaders: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,6 +10,7 @@ const GLOBALS = {
 
 export default {
   debug: true,
+  node: { fs: 'empty' },
   devtool: 'source-map', // more info:https://webpack.github.io/docs/build-performance.html#sourcemaps and https://webpack.github.io/docs/configuration.html#devtool
   noInfo: true, // set to false to see a list of every file being bundled.
   entry: './src/index',
@@ -24,7 +25,8 @@ export default {
     new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.html
     new ExtractTextPlugin('styles.css'),
     new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.UglifyJsPlugin()
+    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.ProvidePlugin({ CodeMirror: 'codemirror' })
   ],
   module: {
     loaders: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -25,8 +25,7 @@ export default {
     new webpack.DefinePlugin(GLOBALS), // Tells React to build in prod mode. https://facebook.github.io/react/downloads.html
     new ExtractTextPlugin('styles.css'),
     new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.UglifyJsPlugin(),
-    new webpack.ProvidePlugin({ CodeMirror: 'codemirror' })
+    new webpack.optimize.UglifyJsPlugin()
   ],
   module: {
     loaders: [


### PR DESCRIPTION
Jekyll Admin was using the fork of [SimpleMDE](simplemde.com) due to some problems with spell checking feature. This PR resolves the issue with the help of Webpack and uses the original repo back again.