### PR TITLE
fix z-index bug in classname meta-buttons

### DIFF
--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -137,7 +137,7 @@
       position: absolute;
       top: 4px;
       right: 0;
-      z-index: 10;
+      z-index: 8;
       .meta-button {
         color: #9098A3;
         font-size: 13px;


### PR DESCRIPTION
the meta-buttons are currently visible even when the full-screen editor is active.
This patch fixes that by reducing the `z-index` attrib.