### PR TITLE
restrict meta-key length

### DIFF
--- a/src/components/metadata/MetaField.js
+++ b/src/components/metadata/MetaField.js
@@ -53,7 +53,8 @@ export class MetaField extends Component {
             defaultValue={fieldKey}
             className="field key-field"
             type="text"
-            placeholder="Key" />
+            placeholder="Key"
+            maxLength="21" />
           <MetaButtons
             currentType={type}
             parentType="top"


### PR DESCRIPTION
restrict metadata-key length to a max 21 characters in compliance with current style definitions
![ja2](https://cloud.githubusercontent.com/assets/12479464/19835639/19227150-9eb3-11e6-9390-8dd1cd158454.png)
