### PR TITLE
Fix test warnings

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -44,7 +44,7 @@ class Editor extends Component {
 }
 
 Editor.propTypes = {
-  json: PropTypes.object.isRequired,
+  json: PropTypes.any.isRequired,
   onEditorChange: PropTypes.func.isRequired,
   editorChanged: PropTypes.bool.isRequired
 };

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -11,20 +11,21 @@ const defaultProps = {
   config,
   editorChanged: false,
   updated: false,
+  router: {},
+  route: {},
   onEditorChange: expect.createSpy(),
   putConfig: expect.createSpy()
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const component = shallow(<Configuration {...props} />);
-
   return {
     component,
     props,
     editor: component.find(Editor),
     saveButton: component.find('a')
   };
-}
+};
 
 describe('Containers::Configuration', () => {
   it('should render correctly with initial props', () => {

--- a/src/containers/views/tests/datafileedit.spec.js
+++ b/src/containers/views/tests/datafileedit.spec.js
@@ -9,12 +9,14 @@ const defaultProps = {
   datafile: {},
   updated: false,
   datafileChanged: false,
+  router: {},
+  route: {},
   params: { data_file: "data_file" },
   errors: [],
   isFetching: false
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const actions = {
     fetchDataFile: expect.createSpy(),
     putDataFile: expect.createSpy(),
@@ -23,9 +25,7 @@ function setup(props = defaultProps) {
     clearErrors: expect.createSpy()
   };
 
-  const component = shallow(
-    <DataFileEdit {...actions} {...props} />
-  );
+  const component = shallow(<DataFileEdit {...actions} {...props} />);
 
   return {
     component,
@@ -34,7 +34,7 @@ function setup(props = defaultProps) {
     deleteButton: component.find('.content-side').last(),
     props
   };
-}
+};
 
 describe('Containers::DataFileEdit', () => {
   it('should render correctly', () => {

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -10,19 +10,19 @@ const defaultProps = {
   updated: false,
   datafileChanged: false,
   editorChanged: false,
+  router: {},
+  route: {},
   errors: []
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const actions = {
     putDataFile: expect.createSpy(),
     onDataFileChanged: expect.createSpy(),
     clearErrors: expect.createSpy()
   };
 
-  const component = shallow(
-    <DataFileNew {...actions} {...props} />
-  );
+  const component = shallow(<DataFileNew {...actions} {...props} />);
 
   return {
     component,
@@ -30,7 +30,7 @@ function setup(props = defaultProps) {
     saveButton: component.find('.content-side a').first(),
     props
   };
-}
+};
 
 describe('Containers::DataFileNew', () => {
   it('should not call putDataFile if a field is not changed.', () => {

--- a/src/containers/views/tests/documentedit.spec.js
+++ b/src/containers/views/tests/documentedit.spec.js
@@ -13,10 +13,12 @@ const defaultProps = {
   fieldChanged: false,
   updated: false,
   isFetching: false,
+  router: {},
+  route: {},
   params: { id: "the-revenant", collection_name: "movies"}
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const actions = {
     fetchDocument: expect.createSpy(),
     putDocument: expect.createSpy(),
@@ -28,9 +30,7 @@ function setup(props = defaultProps) {
     clearErrors: expect.createSpy()
   };
 
-  const component = shallow(
-    <DocumentEdit {...actions} {...props} />
-  );
+  const component = shallow(<DocumentEdit {...actions} {...props} />);
 
   return {
     component,
@@ -40,7 +40,7 @@ function setup(props = defaultProps) {
     errors: component.find('.error-messages'),
     props
   };
-}
+};
 
 describe('Containers::DocumentEdit', () => {
   it('should call clearErrors before mount', () => {

--- a/src/containers/views/tests/documentnew.spec.js
+++ b/src/containers/views/tests/documentnew.spec.js
@@ -11,10 +11,12 @@ const defaultProps = {
   errors: [],
   fieldChanged: false,
   updated: false,
+  router: {},
+  route: {},
   params: { collection_name: doc.collection }
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const actions = {
     putDocument: expect.createSpy(),
     updateTitle: expect.createSpy(),
@@ -24,9 +26,7 @@ function setup(props = defaultProps) {
     clearErrors: expect.createSpy()
   };
 
-  const component = shallow(
-    <DocumentNew {...actions} {...props} />
-  );
+  const component = shallow(<DocumentNew {...actions} {...props} />);
 
   return {
     component,
@@ -35,7 +35,7 @@ function setup(props = defaultProps) {
     errors: component.find('.error-messages'),
     props
   };
-}
+};
 
 describe('Containers::DocumentNew', () => {
   it('should call clearErrors before mount', () => {

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -13,10 +13,12 @@ const defaultProps = {
   fieldChanged: false,
   updated: false,
   isFetching: false,
+  router: {},
+  route: {},
   params: { id: "page.md"}
 };
 
-function setup(props = defaultProps) {
+const setup = (props = defaultProps) => {
   const actions = {
     fetchPage: expect.createSpy(),
     putPage: expect.createSpy(),
@@ -28,9 +30,7 @@ function setup(props = defaultProps) {
     clearErrors: expect.createSpy()
   };
 
-  const component = shallow(
-    <PageEdit {...actions} {...props} />
-  );
+  const component = shallow(<PageEdit {...actions} {...props} />);
 
   return {
     component,
@@ -40,7 +40,7 @@ function setup(props = defaultProps) {
     errors: component.find('.error-messages'),
     props
   };
-}
+};
 
 describe('Containers::PageEdit', () => {
   it('should call clearErrors before mount', () => {

--- a/src/containers/views/tests/pagenew.spec.js
+++ b/src/containers/views/tests/pagenew.spec.js
@@ -10,7 +10,9 @@ import { page } from './fixtures';
 const defaultProps = {
   errors: [],
   fieldChanged: false,
-  updated: false
+  updated: false,
+  router: {},
+  route: {}
 };
 
 function setup(props = defaultProps) {


### PR DESCRIPTION
Some tests were throwing warnings due to the lack of prop types of React components. This PR adds those missing prop types to test components. 