### PR TITLE
Use `raw_content` for PUT requests to support other formats

### DIFF
--- a/src/actions/datafiles.js
+++ b/src/actions/datafiles.js
@@ -54,15 +54,9 @@ export function putDataFile(filename, data) {
       return dispatch(validationError(errors));
     }
     dispatch({type: ActionTypes.CLEAR_ERRORS});
-    let json;
-    try {
-      json = toJSON(data);
-    } catch (e) {
-      return dispatch(addNotification(getParserErrorMessage(), e.message, 'error'));
-    }
     return put(
       putDataFileUrl(filename),
-      JSON.stringify({ content: json }),
+      JSON.stringify({ raw_content: data }),
       { type: ActionTypes.PUT_DATAFILE_SUCCESS, name: "file"},
       { type: ActionTypes.PUT_DATAFILE_FAILURE, name: "error"},
       dispatch

--- a/src/actions/tests/datafiles.spec.js
+++ b/src/actions/tests/datafiles.spec.js
@@ -90,7 +90,7 @@ describe('Actions::Datafiles', () => {
 
   it('updates a data file successfully', () => {
     nock(API)
-      .put('/data/data_file.yml', { content: { foo: "bar" } } )
+      .put('/data/data_file.json', { raw_content: { foo: "bar" } } )
       .reply(200, datafile);
 
     const expectedAction = [
@@ -100,7 +100,7 @@ describe('Actions::Datafiles', () => {
 
     const store = mockStore({ currentFile: {} });
 
-    return store.dispatch(actions.putDataFile('data_file.yml', 'foo: bar'))
+    return store.dispatch(actions.putDataFile('data_file.json', { foo: "bar" }))
       .then(() => { // return of async actions
         expect(store.getActions()).toEqual(expectedAction);
       });

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -4,11 +4,9 @@ import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/github';
 
-import { toYAML } from '../utils/helpers';
-
 class Editor extends Component {
   shouldComponentUpdate(nextProps, nextState) {
-    return nextProps.json !== this.props.json;
+    return nextProps.content !== this.props.content;
   }
 
   handleChange(value) {
@@ -24,10 +22,10 @@ class Editor extends Component {
   }
 
   render() {
-    const { json } = this.props;
+    const { content } = this.props;
     return (
       <AceEditor
-        value={toYAML(json)}
+        value={content}
         mode="yaml"
         theme="github"
         width="100%"
@@ -44,7 +42,7 @@ class Editor extends Component {
 }
 
 Editor.propTypes = {
-  json: PropTypes.any.isRequired,
+  content: PropTypes.any.isRequired,
   onEditorChange: PropTypes.func.isRequired,
   editorChanged: PropTypes.bool.isRequired
 };

--- a/src/components/tests/editor.spec.js
+++ b/src/components/tests/editor.spec.js
@@ -1,13 +1,10 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-
 import Editor from '../Editor';
-import { toYAML } from '../../utils/helpers';
-
 import { json } from './fixtures';
 
-function setup(props = {json, editorChanged: false}) {
+function setup(props = {content: json, editorChanged: false}) {
   const actions = {
     onEditorChange: expect.createSpy()
   };
@@ -26,7 +23,7 @@ function setup(props = {json, editorChanged: false}) {
 describe('Components::Editor', () => {
   it('should render correctly', () => {
     const { component, editor } = setup();
-    expect(editor.prop('value')).toEqual(toYAML(json));
+    expect(editor.prop('value')).toEqual(json);
   });
   it('should call onEditorChange if editor is not changed', () => {
     const { actions, editor, component } = setup();
@@ -34,7 +31,7 @@ describe('Components::Editor', () => {
     expect(actions.onEditorChange).toHaveBeenCalled();
   });
   it('should not call onEditorChange again if editor is already changed', () => {
-    const { actions, editor } = setup({ json, editorChanged: true });
+    const { actions, editor } = setup({ content: json, editorChanged: true });
     editor.simulate('change');
     expect(actions.onEditorChange).toNotHaveBeenCalled();
   });

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router';
 import Editor from '../../components/Editor';
 import { putConfig, onEditorChange } from '../../actions/config';
 import { getLeaveMessage } from '../../constants/messages';
+import { toYAML } from '../../utils/helpers';
 
 export class Configuration extends Component {
 
@@ -43,7 +44,7 @@ export class Configuration extends Component {
         <Editor
           editorChanged={editorChanged}
           onEditorChange={onEditorChange}
-          json={config}
+          content={toYAML(config)}
           ref="editor" />
       </div>
     );

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -58,7 +58,7 @@ export class DataFileEdit extends Component {
       return <h1>{getNotFoundMessage("data file")}</h1>;
     }
 
-    const { slug, ext, raw_content, content } = datafile;
+    const { slug, ext, raw_content } = datafile;
     const filename = slug+ext;
 
     return (
@@ -80,7 +80,7 @@ export class DataFileEdit extends Component {
             <Editor
               editorChanged={datafileChanged}
               onEditorChange={onDataFileChanged}
-              json={content}
+              content={raw_content}
               ref="editor" />
           </div>
 

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -66,7 +66,7 @@ export class DataFileNew extends Component {
             <Editor
               editorChanged={datafileChanged}
               onEditorChange={onDataFileChanged}
-              json={''}
+              content={''}
               ref="editor" />
           </div>
 

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -2,9 +2,8 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import expect from 'expect';
 import Editor from '../../../components/Editor';
-
 import { Configuration } from '../Configuration';
-
+import { toYAML } from '../../../utils/helpers';
 import { config } from './fixtures';
 
 const defaultProps = {
@@ -32,7 +31,7 @@ describe('Containers::Configuration', () => {
     const { component, editor, saveButton } = setup();
     expect(saveButton.text()).toBe('Save');
     expect(saveButton.prop('className').trim()).toBe('btn btn-inactive');
-    expect(editor.prop('json')).toEqual(config);
+    expect(editor.prop('content')).toEqual(toYAML(config));
   });
 
   it('should render correctly with updated props', () => {


### PR DESCRIPTION
With this PR, the front end sends PUT requests for data files with `raw_content` instead of `content`. This way, the backend saves the content of data files to disk as they are rather than parsing to `yaml` ([code](https://github.com/jekyll/jekyll-admin/blob/master/lib/jekyll-admin/server/data.rb#L37)). This will allows us to create/update data files in any format.

Closes #106 and closes #108.
