### PR TITLE
Prune frontend state tree

### DIFF
--- a/docs/frontend/actions.md
+++ b/docs/frontend/actions.md
@@ -35,7 +35,7 @@ from `state.metadata`
 
 ### `deletePage(id)`
 
-Async action for deleting the requested page.
+Async action for deleting the requested page. After deletion, page list is requested.
 
 ## Collections
 
@@ -57,7 +57,7 @@ Async action for creating/updating the requested document. The response includes
 
 ### `deleteDocument(collection_name, id)`
 
-Async action for deleting the document from disk.
+Async action for deleting the document from disk. After deletion, collection is requested.
 
 ## Metadata
 
@@ -120,7 +120,7 @@ It encodes the uploaded `File` objects to `base64` before sending PUT request.
 
 ### `deleteStaticFile(filename)`
 
-Async action for deleting the requested static file.
+Async action for deleting the requested static file. After deletion, static file list is requested.
 
 ## Data Files
 
@@ -138,7 +138,7 @@ Async action for creating/updating the requested data file. It validates the giv
 
 ### `deleteDataFile(filename)`
 
-Async action for deleting the requested data file.
+Async action for deleting the requested data file. After deletion, data file list is requested.
 
 ### `onDataFileChanged`
 

--- a/docs/frontend/reducers.md
+++ b/docs/frontend/reducers.md
@@ -38,7 +38,6 @@ State;
 {
   collections: Array,
   currentCollection: Object,
-  currentDocuments: Array,
   currentDocument: Object,
   isFetching: Boolean, // set to true when the document is being fetched
   updated: Boolean // set to true when the document is updated

--- a/src/actions/collections.js
+++ b/src/actions/collections.js
@@ -108,10 +108,23 @@ export function putDocument(id, collection) {
 }
 
 export function deleteDocument(id, collection) {
-  return (dispatch) => del(
-    deleteCollectionDocumentUrl(collection, id),
-    { type: ActionTypes.DELETE_DOCUMENT_SUCCESS, id },
-    { type: ActionTypes.DELETE_DOCUMENT_FAILURE, name: "error"},
-    dispatch
-  );
+  return (dispatch) => {
+    return fetch(deleteCollectionDocumentUrl(collection, id), {
+      method: 'DELETE',
+      headers: {
+        'Origin': 'http://localhost:3000',
+        'Access-Control-Request-Method': 'DELETE'
+      }
+    })
+    .then(data => {
+      dispatch({
+        type: ActionTypes.DELETE_DOCUMENT_SUCCESS
+      });
+      dispatch(fetchCollection(collection));
+    })
+    .catch(error => dispatch({
+      type: ActionTypes.DELETE_DOCUMENT_FAILURE,
+      error
+    }));
+  };
 }

--- a/src/actions/collections.js
+++ b/src/actions/collections.js
@@ -110,11 +110,7 @@ export function putDocument(id, collection) {
 export function deleteDocument(id, collection) {
   return (dispatch) => {
     return fetch(deleteCollectionDocumentUrl(collection, id), {
-      method: 'DELETE',
-      headers: {
-        'Origin': 'http://localhost:3000',
-        'Access-Control-Request-Method': 'DELETE'
-      }
+      method: 'DELETE'
     })
     .then(data => {
       dispatch({

--- a/src/actions/datafiles.js
+++ b/src/actions/datafiles.js
@@ -63,12 +63,25 @@ export function putDataFile(filename, data) {
 }
 
 export function deleteDataFile(filename) {
-  return (dispatch) => del(
-    deleteDataFileUrl(filename),
-    { type: ActionTypes.DELETE_DATAFILE_SUCCESS, id: filename},
-    { type: ActionTypes.DELETE_DATAFILE_FAILURE, name: "error"},
-    dispatch
-  );
+  return (dispatch) => {
+    return fetch(deleteDataFileUrl(filename), {
+      method: 'DELETE',
+      headers: {
+        'Origin': 'http://localhost:3000',
+        'Access-Control-Request-Method': 'DELETE'
+      }
+    })
+    .then(data => {
+      dispatch({
+        type: ActionTypes.DELETE_DATAFILE_SUCCESS
+      });
+      dispatch(fetchDataFiles());
+    })
+    .catch(error => dispatch({
+      type: ActionTypes.DELETE_DATAFILE_FAILURE,
+      error
+    }));
+  };
 }
 
 export function onDataFileChanged() {

--- a/src/actions/datafiles.js
+++ b/src/actions/datafiles.js
@@ -65,11 +65,7 @@ export function putDataFile(filename, data) {
 export function deleteDataFile(filename) {
   return (dispatch) => {
     return fetch(deleteDataFileUrl(filename), {
-      method: 'DELETE',
-      headers: {
-        'Origin': 'http://localhost:3000',
-        'Access-Control-Request-Method': 'DELETE'
-      }
+      method: 'DELETE'
     })
     .then(data => {
       dispatch({

--- a/src/actions/pages.js
+++ b/src/actions/pages.js
@@ -77,11 +77,7 @@ export function putPage(name) {
 export function deletePage(id) {
   return (dispatch) => {
     return fetch(deletePageUrl(id), {
-      method: 'DELETE',
-      headers: {
-        'Origin': 'http://localhost:3000',
-        'Access-Control-Request-Method': 'DELETE'
-      }
+      method: 'DELETE'
     })
     .then(data => {
       dispatch({

--- a/src/actions/pages.js
+++ b/src/actions/pages.js
@@ -75,10 +75,23 @@ export function putPage(name) {
 }
 
 export function deletePage(id) {
-  return (dispatch) => del(
-    deletePageUrl(id),
-    { type: ActionTypes.DELETE_PAGE_SUCCESS, id},
-    { type: ActionTypes.DELETE_PAGE_FAILURE, name: "error"},
-    dispatch
-  );
+  return (dispatch) => {
+    return fetch(deletePageUrl(id), {
+      method: 'DELETE',
+      headers: {
+        'Origin': 'http://localhost:3000',
+        'Access-Control-Request-Method': 'DELETE'
+      }
+    })
+    .then(data => {
+      dispatch({
+        type: ActionTypes.DELETE_PAGE_SUCCESS
+      });
+      dispatch(fetchPages());
+    })
+    .catch(error => dispatch({
+      type: ActionTypes.DELETE_PAGE_FAILURE,
+      error
+    }));
+  };
 }

--- a/src/actions/staticfiles.js
+++ b/src/actions/staticfiles.js
@@ -68,11 +68,7 @@ export function uploadStaticFiles(files) {
 export function deleteStaticFile(filename) {
   return (dispatch) => {
     return fetch(deleteStaticFileUrl(filename), {
-      method: 'DELETE',
-      headers: {
-        'Origin': 'http://localhost:3000',
-        'Access-Control-Request-Method': 'DELETE'
-      }
+      method: 'DELETE'
     })
     .then(data => {
       dispatch({

--- a/src/actions/tests/collections.spec.js
+++ b/src/actions/tests/collections.spec.js
@@ -78,7 +78,8 @@ describe('Actions::Collections', () => {
       .reply(200);
 
     const expectedActions = [
-      { id: filename, type: types.DELETE_DOCUMENT_SUCCESS }
+      { type: types.DELETE_DOCUMENT_SUCCESS },
+      { type: types.FETCH_COLLECTION_REQUEST }
     ];
 
     const store = mockStore({});

--- a/src/actions/tests/datafiles.spec.js
+++ b/src/actions/tests/datafiles.spec.js
@@ -130,7 +130,8 @@ describe('Actions::Datafiles', () => {
       .reply(200);
 
     const expectedAction = [
-      { type: types.DELETE_DATAFILE_SUCCESS, id: 'data_file.yml' }
+      { type: types.DELETE_DATAFILE_SUCCESS },
+      { type: types.FETCH_DATAFILES_REQUEST }
     ];
 
     const store = mockStore({ files: [] });

--- a/src/actions/tests/pages.spec.js
+++ b/src/actions/tests/pages.spec.js
@@ -58,7 +58,8 @@ describe('Actions::Pages', () => {
       .reply(200);
 
     const expectedActions = [
-      { id: page.name, type: types.DELETE_PAGE_SUCCESS }
+      { type: types.DELETE_PAGE_SUCCESS },
+      { type: types.FETCH_PAGES_REQUEST }
     ];
 
     const store = mockStore({});

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -52,8 +52,8 @@ export class Documents extends Component {
   }
 
   renderRows() {
-    const { currentDocuments } = this.props;
-    return _.map(currentDocuments, doc => {
+    const { documents } = this.props;
+    return _.map(documents, doc => {
       const { id, slug, title, http_url, ext, collection, path } = doc;
       const filename = path.substring(path.lastIndexOf('/') + 1);
       const to = `${ADMIN_PREFIX}/collections/${collection}/${filename}`;
@@ -83,7 +83,7 @@ export class Documents extends Component {
   }
 
   render() {
-    const { isFetching, currentDocuments, search, params } = this.props;
+    const { isFetching, documents, search, params } = this.props;
     const { collection_name } = params;
 
     if (isFetching) {
@@ -102,10 +102,10 @@ export class Documents extends Component {
           </div>
         </div>
         {
-          currentDocuments.length > 0 && this.renderTable()
+          documents.length > 0 && this.renderTable()
         }
         {
-          !currentDocuments.length && <h1>{getNotFoundMessage("documents")}</h1>
+          !documents.length && <h1>{getNotFoundMessage("documents")}</h1>
         }
       </div>
     );
@@ -114,7 +114,7 @@ export class Documents extends Component {
 
 Documents.propTypes = {
   isFetching: PropTypes.bool.isRequired,
-  currentDocuments: PropTypes.array.isRequired,
+  documents: PropTypes.array.isRequired,
   fetchCollection: PropTypes.func.isRequired,
   deleteDocument: PropTypes.func.isRequired,
   search: PropTypes.func.isRequired,
@@ -122,7 +122,10 @@ Documents.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  currentDocuments: filterByTitle(state.collections.currentDocuments, state.utils.input),
+  documents: filterByTitle(
+    state.collections.currentCollection.documents,
+    state.utils.input
+  ),
   isFetching: state.collections.isFetching
 });
 

--- a/src/containers/views/tests/documents.spec.js
+++ b/src/containers/views/tests/documents.spec.js
@@ -7,7 +7,7 @@ import { Documents } from '../Documents';
 
 import { doc } from './fixtures';
 
-function setup(currentDocuments=[doc]) {
+function setup(documents=[doc]) {
   const actions = {
     fetchCollection: expect.createSpy(),
     deleteDocument: expect.createSpy(),
@@ -16,7 +16,7 @@ function setup(currentDocuments=[doc]) {
 
   const component = mount(
     <Documents
-      currentDocuments={currentDocuments}
+      documents={documents}
       {...actions}
       params={{collection_name: "movies"}}
       isFetching={false} />

--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -11,7 +11,6 @@ import _ from 'underscore';
 export default function collections(state = {
   collections: [],
   currentCollection: {},
-  currentDocuments: [],
   currentDocument: {},
   isFetching: false,
   updated: false
@@ -31,7 +30,6 @@ export default function collections(state = {
     case FETCH_COLLECTION_SUCCESS:
       return Object.assign({}, state, {
         currentCollection: action.collection,
-        currentDocuments: action.collection.documents,
         isFetching: false
       });
     case FETCH_DOCUMENT_SUCCESS:
@@ -44,13 +42,6 @@ export default function collections(state = {
     case FETCH_DOCUMENT_FAILURE:
       return Object.assign({}, state, {
         isFetching: false
-      });
-    case DELETE_DOCUMENT_SUCCESS:
-      return Object.assign({}, state, {
-        currentDocuments: _.filter(state.currentDocuments, doc => {
-          const filename = doc.path.substring(doc.path.lastIndexOf('/') + 1);
-          return filename != action.id;
-        })
       });
     case PUT_DOCUMENT_SUCCESS:
       return Object.assign({}, state, {
@@ -66,6 +57,9 @@ export default function collections(state = {
 
 // Selectors
 export const filterByTitle = (list, input) => {
+  if (!list) {
+    return [];
+  }
   if (input) {
     return list.filter(
       p => p.title.toLowerCase().indexOf(input.toLowerCase()) > -1

--- a/src/reducers/datafiles.js
+++ b/src/reducers/datafiles.js
@@ -51,12 +51,6 @@ export default function datafiles(state = {
       return Object.assign({}, state, {
         datafileChanged: false
       });
-    case DELETE_DATAFILE_SUCCESS:
-      return Object.assign({}, state, {
-        files: _.filter(state.files, file => {
-          return (file.slug+file.ext) != action.id;
-        })
-      });
     case DATAFILE_CHANGED:
       return Object.assign({}, state, {
         datafileChanged: true,

--- a/src/reducers/pages.js
+++ b/src/reducers/pages.js
@@ -44,10 +44,6 @@ export default function pages(state = {
         page: action.page,
         updated: true
       });
-    case DELETE_PAGE_SUCCESS:
-      return Object.assign({}, state, {
-        pages: _.filter(state.pages, page => page.name != action.id)
-      });
     default:
       return Object.assign({}, state, {
         updated: false

--- a/src/reducers/tests/collections.spec.js
+++ b/src/reducers/tests/collections.spec.js
@@ -9,7 +9,6 @@ describe('Reducers::Collections', () => {
     expect(reducer(undefined, {})).toEqual({
       currentCollection: {},
       currentDocument: {},
-      currentDocuments: [],
       collections: [],
       isFetching: false,
       updated: false
@@ -57,7 +56,6 @@ describe('Reducers::Collections', () => {
       })
     ).toEqual({
       currentCollection: collection,
-      currentDocuments: collection.documents,
       isFetching: false
     });
     expect(
@@ -66,17 +64,6 @@ describe('Reducers::Collections', () => {
       })
     ).toEqual({
       isFetching: false
-    });
-  });
-
-  it('should handle deleteDocument', () => {
-    expect(
-      reducer({ currentDocuments: [doc] }, {
-        type: types.DELETE_DOCUMENT_SUCCESS,
-        id: doc.path.substring(doc.path.lastIndexOf('/') + 1)
-      })
-    ).toEqual({
-      currentDocuments: []
     });
   });
 

--- a/src/reducers/tests/datafiles.spec.js
+++ b/src/reducers/tests/datafiles.spec.js
@@ -97,17 +97,6 @@ describe('Reducers::DataFiles', () => {
     });
   });
 
-  it('should handle deleteDataFile', () => {
-    expect(
-      reducer({ files: [datafile] }, {
-        type: types.DELETE_DATAFILE_SUCCESS,
-        id : "data_file.yml"
-      })
-    ).toEqual({
-      files: []
-    });
-  });
-
   it('should handle datafileChanged', () => {
     expect(
       reducer({ updated: true }, {

--- a/src/reducers/tests/pages.spec.js
+++ b/src/reducers/tests/pages.spec.js
@@ -69,17 +69,6 @@ describe('Reducers::Pages', () => {
     });
   });
 
-  it('should handle deletePages', () => {
-    expect(
-      reducer({ pages: [{name:1},{name:2}] }, {
-        type: types.DELETE_PAGE_SUCCESS,
-        id: 1
-      })
-    ).toEqual({
-      pages: [{name:2}]
-    });
-  });
-
   it('should handle putPage', () => {
     expect(
       reducer({}, {

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -47,10 +47,6 @@ export const get = (url, action_success, action_failure, dispatch) => {
 export const put = (url, body, action_success, action_failure, dispatch) => {
   return fetch(url, {
     method: 'PUT',
-    headers: {
-      'Origin': 'http://localhost:3000',
-      'Access-Control-Request-Method': 'PUT'
-    },
     body
   })
   .then(res => res.json())


### PR DESCRIPTION
Content of the PR;

- [x] After #211, `collections/collection/documents/` endpoint is deprecated and `documents` key is moved to `collections/collection/path` endpoint. With this API change, the front end is fetching a collection and its documents with a single call. This allows us to store the information from that call in a single object rather than storing collections and documents of currently visited collection separately.

**Before;**

![before](https://cloud.githubusercontent.com/assets/7414026/21730241/84c7dac4-d457-11e6-8e4c-650997e26ac3.png)

**After `currentDocuments` removed;**

![after](https://cloud.githubusercontent.com/assets/7414026/21730257/96815be6-d457-11e6-9363-672df6d48eec.png)

- [x] Secondly, the front end now follows another method of deleting files. Formerly, once a file was deleted, it was filtered out from the list state until another request was made for that list. Now once it is deleted, a new list request is made rather than relying on the state. This ensures that the front end state is the same as the back end's.
