### PR TITLE
Use 'monokai' theme in `Editor` component

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import brace from 'brace';
 import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
-import 'brace/theme/github';
+import 'brace/theme/monokai';
 
 class Editor extends Component {
   shouldComponentUpdate(nextProps, nextState) {
@@ -27,7 +27,7 @@ class Editor extends Component {
       <AceEditor
         value={content}
         mode="yaml"
-        theme="github"
+        theme="monokai"
         width="100%"
         height="400px"
         showGutter={false}


### PR DESCRIPTION
The current theme `github` used in the [**`Editor.js`**](https://github.com/jekyll/jekyll-admin/blob/master/src/components/Editor.js#L30) component is rather bland and doesn't seem to impart optimal syntax highlighting.

This PR proposes to use the `monokai` theme.
- optimal syntax-highlighting
- dark-background offers optimal contrast.

![theme](https://cloud.githubusercontent.com/assets/12479464/21757438/c6936ec4-d654-11e6-8891-2b12d12f9918.png)
