### PR TITLE
Remove unused API fields

### DIFF
--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -13,7 +13,6 @@ describe JekyllAdmin::APIable do
       [false, true].each do |with_content|
         context "#{with_content ? "with" : "without"} content" do
           let(:as_api) { subject.to_api(:include_content => with_content) }
-          let(:content)  { as_api["content"] }
           let(:raw_content)  { as_api["raw_content"] }
           let(:front_matter) { as_api["front_matter"] }
 
@@ -21,14 +20,18 @@ describe JekyllAdmin::APIable do
             expect(subject).to respond_to(:to_api)
           end
 
+          it "does not include the omitted fields" do
+            expect(as_api).to_not have_key("content")
+            expect(as_api).to_not have_key("output")
+            expect(as_api).to_not have_key("excerpt")
+            expect(as_api).to_not have_key("next")
+            expect(as_api).to_not have_key("previous")
+            expect(as_api).to_not have_key("url")
+          end
+
           if with_content
             it "includes the raw_content" do
               expect(raw_content).to eql("# Test #{type.to_s.capitalize}\n")
-            end
-
-            it "includes the rendered content" do
-              expected = "<h1 id=\"test-#{type}\">Test #{type.capitalize}</h1>\n"
-              expect(content).to eql(expected)
             end
 
             it "includes the raw front matter" do
@@ -45,10 +48,6 @@ describe JekyllAdmin::APIable do
               expect(as_api).to_not have_key("raw_content")
             end
 
-            it "doesn't include the rendered content" do
-              expect(as_api).to_not have_key("content")
-              expect(as_api).to_not have_key("output")
-            end
           end
 
           it "includes front matter defaults as top-level keys" do

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -54,7 +54,7 @@ describe JekyllAdmin::DataFile do
         })
       end
 
-      it "returns the hash with content" do
+      it "returns the hash with raw content" do
         expect(subject.to_api(:include_content => true)).to eql({
           "path"          => "_data/data_file.yml",
           "relative_path" => "_data/data_file.yml",
@@ -62,9 +62,6 @@ describe JekyllAdmin::DataFile do
           "ext"           => ".yml",
           "title"         => "Data File",
           "raw_content"   => "foo: bar\n",
-          "content"       => {
-            "foo" => "bar"
-          },
           "api_url"       => "http://localhost:4000/_api/data/data_file.yml",
           "http_url"      => nil
         })

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -109,36 +109,10 @@ describe "collections" do
       expect(last_response_parsed["breed"]).to eq("Golden Retriever")
     end
 
-    it "returns the rendered output" do
-      get "/collections/posts/2016-01-01-test.md"
-      expect(last_response).to be_ok
-      expected = "<h1 id=\"test-post\">Test Post</h1>\n"
-      expect(last_response_parsed["content"]).to eq(expected)
-    end
-
     it "returns the raw content" do
       get "/collections/posts/2016-01-01-test.md"
       expect(last_response).to be_ok
       expect(last_response_parsed["raw_content"]).to eq("# Test Post\n")
-    end
-
-    %w(next previous).each do |direction|
-      it "includes the #{direction} document non-recursively" do
-        get "/collections/posts/2016-02-01-test.md"
-        expect(last_response).to be_ok
-        expect(last_response_parsed).to have_key(direction)
-        expect(last_response_parsed[direction]).to_not have_key("next")
-        expect(last_response_parsed[direction]).to_not have_key("previous")
-      end
-
-      it "doesn't include the #{direction} document's content" do
-        get "/collections/posts/2016-02-01-test.md"
-        expect(last_response).to be_ok
-        expect(last_response_parsed).to have_key(direction)
-        expect(last_response_parsed[direction]).to_not have_key("content")
-        expect(last_response_parsed[direction]).to_not have_key("raw_content")
-        expect(last_response_parsed[direction]).to_not have_key("output")
-      end
     end
 
     context "front matter" do

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -15,10 +15,7 @@ describe "data" do
 
   let(:response_with_content) do
     base_response.merge({
-      "raw_content" => "foo: bar\n",
-      "content"     => {
-        "foo" => "bar"
-      }
+      "raw_content" => "foo: bar\n"
     })
   end
 
@@ -54,9 +51,6 @@ describe "data" do
       "ext"           => ".yml",
       "title"         => "Data File New",
       "raw_content"   => "foo: bar\n",
-      "content"       => {
-        "foo" => "bar"
-      },
       "api_url"       => "http://localhost:4000/_api/data/data-file-new.yml",
       "http_url"      => nil
     }
@@ -81,9 +75,6 @@ describe "data" do
       "ext"           => ".yml",
       "title"         => "Data File New",
       "raw_content"   => "foo: bar\n",
-      "content"       => {
-        "foo" => "bar"
-      },
       "api_url"       => "http://localhost:4000/_api/data/data-file-new.yml",
       "http_url"      => nil
     }
@@ -108,9 +99,6 @@ describe "data" do
       "ext"           => ".yml",
       "title"         => "Data File Update",
       "raw_content"   => "foo: bar2\n",
-      "content"       => {
-        "foo" => "bar2"
-      },
       "api_url"       => "http://localhost:4000/_api/data/data-file-update.yml",
       "http_url"      => nil
     }

--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -55,13 +55,6 @@ describe "pages" do
       expect(last_response_parsed["foo"]).to eq("bar")
     end
 
-    it "returns the rendered output" do
-      get "/pages/page.md"
-      expect(last_response).to be_ok
-      expected = "<h1 id=\"test-page\">Test Page</h1>\n"
-      expect(last_response_parsed["content"]).to eq(expected)
-    end
-
     it "returns the raw content" do
       get "/pages/page.md"
       expect(last_response).to be_ok


### PR DESCRIPTION
Some of the fields were not being used by the front end. This PR removes them from the API output.

These are the omitted fields;

- `content` => front end uses `raw_content` instead in order to keep the files as they are
- `excerpt`
- `output` 
- `next` & `previous` documents
- `url` => we have `http_url`