### PR TITLE
Fix uploading files on Windows

### DIFF
--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -72,9 +72,10 @@ module JekyllAdmin
     def write_file(path, content)
       path = sanitized_path(path)
       FileUtils.mkdir_p File.dirname(path)
-      file = File.write path, content
+      File.open(path, "wb") do |file|
+        file.write(content)
+      end
       site.process
-      file
     end
 
     def delete_file(path)


### PR DESCRIPTION
This PR adds binary file mode option when writing static files.

Fixes #206 