### PR TITLE
Fix encoding bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 # Site dependencies
-gem 'minima'
 gem 'jekyll-seo-tag'
 gem 'jekyll-sitemap'

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -30,7 +30,7 @@ module JekyllAdmin
 
     # Returns unparsed content as it exists on disk
     def raw_content
-      @raw_content ||= File.read(absolute_path)
+      @raw_content ||= File.open(absolute_path, "r:UTF-8", &:read)
     end
 
     # Returnes (re)parsed content using Jekyll's native parsing mechanism

--- a/spec/jekyll-admin/server/configuration_spec.rb
+++ b/spec/jekyll-admin/server/configuration_spec.rb
@@ -15,7 +15,7 @@ describe "configuration" do
   it "updates the configuration" do
     config_path   = File.expand_path "_config.yml", fixture_path("site")
     config_body   = File.read(config_path)
-    config_before = YAML.load(config_body)
+    config_before = SafeYAML.load(config_body)
     config = config_before.dup
 
     config["foo"] = "bar2"
@@ -33,7 +33,7 @@ describe "configuration" do
   it "doesn't inject the default collections" do
     config_path   = File.expand_path "_config.yml", fixture_path("site")
     config_body   = File.read(config_path)
-    config_before = YAML.load(config_body)
+    config_before = SafeYAML.load(config_body)
 
     config = config_before.dup
     config["collections"]["test"] = { "foo" => "bar" }


### PR DESCRIPTION
Fixes #257

@ashmaroli Looks like the problem is that API is reading data files' `raw_content` in a non-utf format. I was thinking that was Ace Editor causing the bug.

/cc @benbalter 