### PR TITLE
Frontend Improvements

### DIFF
--- a/docs/_frontend/components.md
+++ b/docs/_frontend/components.md
@@ -27,7 +27,7 @@ Can have [all options of SimpleMDE](https://github.com/NextStepWebs/simplemde-ma
 ## Breadcrumbs
 
 Component for generating breadcrumbs. First breadcrumb indicates the current content
-type and the second one which is editable is the path of current item.
+type and the second one which can be either an input or a label is the path of the current item.
 
 ### PropTypes
 
@@ -35,8 +35,40 @@ type and the second one which is editable is the path of current item.
 {
   link: String, // Link to the corresponding content type
   type: String, // Content type (pages, collections..)
-  path: String, // File path
+  content: String, // File path
+  editable: Boolean, // can be editable or not
   onChange: Function // triggered when the path changes
+}
+```
+
+## Errors
+
+Component for listing the validation errors
+
+### PropTypes
+
+```javascript
+{
+  errors: Array // Array of error messages
+}
+```
+
+## Button
+
+Generic component for button element.
+
+### PropTypes
+
+```javascript
+{
+  type: String, // type of the button ('save', 'create', 'view', 'upload' etc.)
+  active: Boolean, // state of the button
+  onClick: Function, // callback function triggered when the button is clicked
+  triggered: PropTypes.bool, // click state
+  block: PropTypes.bool, // should the button fill the parent width
+  thin: PropTypes.bool, // should the button be small
+  icon: PropTypes.string, // displays icon if icon name is given
+  to: PropTypes.string // links to the given URL. If set, onClick is disabled
 }
 ```
 

--- a/docs/_frontend/constants.md
+++ b/docs/_frontend/constants.md
@@ -6,18 +6,11 @@ title: Constants
 
 Stores all of the action creators' names
 
-## Messages
+## Lang
 
-Stores the following messages;
+Stores the language specific files. Selected language strings are exported from `index.js`.
 
-* `confirm delete message`
-* `confirm leave message`
-* `confirm override static file message`
-* `not found message`
-* `notification messages`
-* `validation messages`
-
-This allows us to control all of the messages in a single place and also will help us localize the admin panel in the future.
+This allows us to control all of the language specific strings in a single place and also will help us localize the admin panel in the future.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "brace": "0.9.1",
+    "classnames": "^2.2.5",
     "isomorphic-fetch": "^2.2.1",
     "js-yaml": "^3.6.1",
     "lodash": "^4.13.1",

--- a/src/actions/collections.js
+++ b/src/actions/collections.js
@@ -9,7 +9,7 @@ import {
   getTitleRequiredMessage,
   getFilenameRequiredMessage,
   getFilenameNotValidMessage
-} from '../constants/messages';
+} from '../constants/lang';
 import {
   getCollectionsUrl,
   getCollectionUrl,

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -1,6 +1,6 @@
 import * as ActionTypes from '../constants/actionTypes';
 import { getConfigurationUrl, putConfigurationUrl } from '../constants/api';
-import { getParserErrorMessage } from '../constants/messages';
+import { getParserErrorMessage } from '../constants/lang';
 import { addNotification } from './notifications';
 import { get, put } from '../utils/fetch';
 import { toJSON } from '../utils/helpers';

--- a/src/actions/datafiles.js
+++ b/src/actions/datafiles.js
@@ -7,7 +7,7 @@ import {
   getParserErrorMessage,
   getContentRequiredMessage,
   getFilenameRequiredMessage
-} from '../constants/messages';
+} from '../constants/lang';
 import {
   getDataFilesUrl,
   getDataFileUrl,

--- a/src/actions/pages.js
+++ b/src/actions/pages.js
@@ -8,7 +8,7 @@ import {
   getTitleRequiredMessage,
   getFilenameRequiredMessage,
   getFilenameNotValidMessage
-} from '../constants/messages';
+} from '../constants/lang';
 import {
   getPagesUrl,
   getPageUrl,

--- a/src/actions/staticfiles.js
+++ b/src/actions/staticfiles.js
@@ -7,7 +7,7 @@ import {
   getErrorMessage,
   getUploadSuccessMessage,
   getUploadErrorMessage
-} from '../constants/messages';
+} from '../constants/lang';
 import {
   getStaticFilesUrl,
   getStaticFileUrl,

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -12,23 +12,30 @@ export default class Breadcrumbs extends Component {
   }
 
   render() {
-    const { link, type, path } = this.props;
-    let placeholder = 'example.md';
+    const { link, type, content, editable } = this.props;
 
-    if (type == 'posts') {
-      const date = moment().format('YYYY-MM-DD');
-      placeholder = `${date}-your-title.md`;
-    }else if (type == 'data files') {
-      placeholder = 'your-filename.yml';
+    let node = null;
+    if (editable) {
+      let placeholder = 'example.md';
+      if (type == 'posts') {
+        const date = moment().format('YYYY-MM-DD');
+        placeholder = `${date}-your-title.md`;
+      }else if (type == 'datafiles') {
+        placeholder = 'your-filename.yml';
+      }
+      node = (<input onChange={(e) => this.handleChange(e)}
+        placeholder={placeholder}
+        defaultValue={content}
+        ref="input" />);
+    } else {
+      node = content;
     }
+
     return (
       <ul className="breadcrumbs">
         <li><Link to={link}>{toTitleCase(type)}</Link></li>
         <li className="filename">
-          <input onChange={(e) => this.handleChange(e)}
-            ref="input"
-            placeholder={placeholder}
-            defaultValue={path} />
+          {node}
         </li>
       </ul>
     );
@@ -38,6 +45,7 @@ export default class Breadcrumbs extends Component {
 Breadcrumbs.propTypes = {
   link: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  path: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired
+  content: PropTypes.string.isRequired,
+  editable: PropTypes.bool,
+  onChange: PropTypes.func
 };

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import classnames from 'classnames';
+import { labels } from '../constants/lang';
 
 export default class Button extends Component {
 
@@ -21,21 +22,21 @@ export default class Button extends Component {
     let triggeredLabel = '';
     switch (type) {
       case 'save':
-        label = 'Save';
-        triggeredLabel = 'Saved';
+        label = labels.save.label;
+        triggeredLabel = labels.save.triggeredLabel;
         break;
       case 'create':
-        label = 'Create';
-        triggeredLabel = 'Created';
+        label = labels.create.label;
+        triggeredLabel = labels.create.triggeredLabel;
         break;
       case 'delete':
-        label = 'Delete';
+        label = labels.delete.label;
         break;
       case 'view':
-        label = 'View';
+        label = labels.view.label;
         break;
       case 'upload':
-        label = 'Upload files';
+        label = labels.upload.label;
         break;
       default:
     }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,68 @@
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+
+export default class Button extends Component {
+
+  render() {
+    const { type, active, triggered, onClick, block, thin, icon, to } = this.props;
+
+    const btnClass = classnames({
+      'btn': true,
+      'btn-active': active,
+      'btn-success': active && (type == 'save' || type == 'create'),
+      'btn-delete': type == 'delete',
+      'btn-view': type == 'view',
+      'btn-inactive': !active,
+      'btn-fat': block,
+      'btn-thin': thin
+    });
+
+    let label = '';
+    let triggeredLabel = '';
+    switch (type) {
+      case 'save':
+        label = 'Save';
+        triggeredLabel = 'Saved';
+        break;
+      case 'create':
+        label = 'Create';
+        triggeredLabel = 'Created';
+        break;
+      case 'delete':
+        label = 'Delete';
+        break;
+      case 'view':
+        label = 'View';
+        break;
+      case 'upload':
+        label = 'Upload files';
+        break;
+      default:
+    }
+
+    const iconNode = icon ? <i className={`fa fa-${icon}`} aria-hidden="true"></i> : null;
+    const clickEvent = !to ? onClick : null;
+
+    return (
+      <a href={to}
+        target="_blank"
+        onClick={clickEvent}
+        className={btnClass}>
+          {iconNode}
+          {triggered ? triggeredLabel : label}
+      </a>
+    );
+  }
+
+}
+
+Button.propTypes = {
+  type: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired,
+  onClick: PropTypes.func,
+  triggered: PropTypes.bool,
+  block: PropTypes.bool,
+  thin: PropTypes.bool,
+  icon: PropTypes.string,
+  to: PropTypes.string
+};

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import brace from 'brace';
 import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/monokai';
@@ -34,6 +33,7 @@ class Editor extends Component {
         showPrintMargin={false}
         highlightActiveLine={false}
         className="config-editor"
+        fontSize={14}
         ref="ace"
         onChange={() => this.handleChange()}
       />

--- a/src/components/Errors.js
+++ b/src/components/Errors.js
@@ -1,0 +1,14 @@
+import React, { PropTypes} from 'react';
+import _ from 'underscore';
+
+const Errors = ({errors}) => (
+  <ul className="error-messages">
+    {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
+  </ul>
+);
+
+Errors.propTypes = {
+  errors: PropTypes.array.isRequired
+};
+
+export default Errors;

--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { getDeleteMessage } from '../constants/messages';
+import { getDeleteMessage } from '../constants/lang';
 import { getFilenameFromPath } from '../utils/helpers';
 
 export default class FilePreview extends Component {

--- a/src/components/metadata/MetaButtons.js
+++ b/src/components/metadata/MetaButtons.js
@@ -21,12 +21,12 @@ export class MetaButtons extends Component {
           <span className="meta-button move"><i className="fa fa-arrows"></i></span>
         }
         <span className="dropdown">
-          <button onFocus={() => onDropdownFocus()}
+          <a onFocus={() => onDropdownFocus()}
             onBlur={() => onDropdownBlur()}
             className="meta-button"
-            tabIndex="-1">
+            tabIndex="1">
               <i className="fa fa-chevron-down"></i>
-          </button>
+          </a>
           <div className="dropdown-wrap">
             {
               currentType != 'simple' &&

--- a/src/components/metadata/MetaButtons.js
+++ b/src/components/metadata/MetaButtons.js
@@ -18,7 +18,7 @@ export class MetaButtons extends Component {
       <div className="meta-buttons">
         {
           parentType == 'array' &&
-          <span className="meta-button move"><i className="fa fa-arrows"></i></span>
+          <span className="move"><i className="fa fa-arrows"></i></span>
         }
         <span className="dropdown">
           <a onFocus={() => onDropdownFocus()}

--- a/src/components/metadata/tests/metaarrayitem.spec.js
+++ b/src/components/metadata/tests/metaarrayitem.spec.js
@@ -74,7 +74,7 @@ describe('Components::MetaArrayItem', () => {
   });
   it('should add `showing-dropdown` class when dropdown button is focused', () => {
     const { component, metabuttons } = setup();
-    let dropdownButton = metabuttons.find('button');
+    let dropdownButton = metabuttons.find('.meta-button');
     dropdownButton.simulate('focus');
     expect(
       component.find('.array-item-wrap').node.classList

--- a/src/components/metadata/tests/metafield.spec.js
+++ b/src/components/metadata/tests/metafield.spec.js
@@ -80,7 +80,7 @@ describe('Components::MetaField', () => {
   });
   it('should add `showing-dropdown` class when dropdown button is focused', () => {
     const { component, metabuttons } = setup();
-    let dropdownButton = metabuttons.find('button');
+    let dropdownButton = metabuttons.find('.meta-button');
     dropdownButton.simulate('focus');
     expect(
       component.find('.metafield').node.classList

--- a/src/components/metadata/tests/metaobjectitem.spec.js
+++ b/src/components/metadata/tests/metaobjectitem.spec.js
@@ -81,7 +81,7 @@ describe('Components::MetaObjectItem', () => {
   });
   it('should add `showing-dropdown` class when dropdown button is focused', () => {
     const { component, metabuttons } = setup();
-    let dropdownButton = metabuttons.find('button');
+    let dropdownButton = metabuttons.find('.meta-button');
     dropdownButton.simulate('focus');
     expect(
       component.find('.object-item-wrap').node.classList

--- a/src/components/tests/breadcrumbs.spec.js
+++ b/src/components/tests/breadcrumbs.spec.js
@@ -9,17 +9,19 @@ import Breadcrumbs from '../Breadcrumbs';
 import { content } from './fixtures';
 
 function setup(defaultContent = content) {
-  let actions = {
+  const actions = {
     onChange: expect.createSpy()
   };
-  const link = `/collections/${defaultContent.collection}`;
-  const type = defaultContent.collection;
+
+  const { collection, path, editable } = defaultContent;
+  const link = `/collections/${collection}`;
 
   let component = mount(
     <Breadcrumbs
       link={link}
-      type={type}
-      path={defaultContent.path}
+      type={collection}
+      content={path}
+      editable={editable}
       {...actions}/>
   );
 
@@ -36,13 +38,19 @@ describe('Components::Breadcrumbs', () => {
   it('should render correctly', () => {
     const { component, link, li, input } = setup();
     expect(link.length).toBe(1);
-    expect(
-      link.first().prop('children')
-    ).toBe(capitalize(content.collection));
+    expect(link.first().prop('children')).toBe(capitalize(content.collection));
     expect(input.prop('defaultValue')).toBe(content.path);
   });
+  it('should not render input if not editable', () => {
+    const { input } = setup(Object.assign({}, content, {
+      editable: null
+    }));
+    expect(input.node).toNotExist();
+  });
   it('should prepend date to input value/placeholder for new post', () => {
-    const { input } = setup({ link:'test', collection:'posts', path:'' });
+    const { input } = setup(Object.assign({}, content, {
+      collection: 'posts'
+    }));
     const expectedValue = moment().format('YYYY-MM-DD') + '-your-title.md';
     expect(input.prop('placeholder')).toBe(expectedValue);
   });

--- a/src/components/tests/button.spec.js
+++ b/src/components/tests/button.spec.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import expect from 'expect';
+import { mount } from 'enzyme';
+
+import Button from '../Button';
+const defaultProps = {type: 'save', active: true};
+
+function setup(props=defaultProps) {
+  const actions = {
+    onClick: expect.createSpy()
+  };
+
+  const component = mount(<Button {...props} {...actions} />);
+
+  return {
+    component,
+    link: component.find('a'),
+    icon: component.find('i'),
+    actions
+  };
+}
+
+describe('Components::Button', () => {
+  it('should render correctly', () => {
+    const { link, icon } = setup();
+    expect(link.text()).toBe('Save');
+    expect(icon.node).toNotExist();
+  });
+
+  it('should have correct class names', () => {
+    let { link } = setup();
+    expect(link.prop('className')).toBe('btn btn-active btn-success');
+
+    link = setup(Object.assign({}, defaultProps, {
+      type: 'delete',
+      active: false,
+      block: true
+    })).link;
+    expect(link.prop('className')).toBe('btn btn-delete btn-inactive btn-fat');
+  });
+
+  it('should render triggered text', () => {
+    const { link } = setup(Object.assign({}, defaultProps, {
+      triggered: true
+    }));
+    expect(link.text()).toBe('Saved');
+  });
+
+  it('should render icon', () => {
+    const { icon } = setup(Object.assign({}, defaultProps, {
+      icon: 'eye'
+    }));
+    expect(icon.node).toExist();
+  });
+
+  it('should call onClick', () => {
+    const { link, actions } = setup();
+    link.simulate('click');
+    expect(actions.onClick).toHaveBeenCalled();
+  });
+
+  it('should not call onClick if it is a link', () => {
+    const { link, actions } = setup(Object.assign({}, defaultProps, {
+      to: 'some_link'
+    }));
+    link.simulate('click');
+    expect(actions.onClick).toNotHaveBeenCalled();
+  });
+});

--- a/src/components/tests/errors.spec.js
+++ b/src/components/tests/errors.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import expect from 'expect';
+import { mount } from 'enzyme';
+
+import Errors from '../Errors';
+
+import { errors } from './fixtures';
+
+function setup() {
+
+  let component = mount(<Errors errors={errors} />);
+
+  return {
+    component,
+    listItem: component.find('li')
+  };
+}
+
+describe('Components::Errors', () => {
+  it('should render errors correctly', () => {
+    const { component, listItem } = setup();
+    expect(listItem.length).toBe(errors.length);
+  });
+});

--- a/src/components/tests/fixtures/index.js
+++ b/src/components/tests/fixtures/index.js
@@ -5,7 +5,8 @@ export const content = {
   layout: "default",
   title: "The Revenant",
   path: 'the-revenant.md',
-  draft: false
+  draft: false,
+  editable: true
 };
 
 export const json = {
@@ -24,3 +25,8 @@ export const staticfile = {
   path: "/logo.png",
   encoded_content: "PGh0bWw+CiAgPGJvZHk+CiAgICBZb3UncmUgcHJvYmFibHkgbG9va2luZyBm"
 };
+
+export const errors = [
+  'The filename is invalid',
+  'The title is required'
+];

--- a/src/constants/lang/en.js
+++ b/src/constants/lang/en.js
@@ -45,3 +45,33 @@ export const getContentRequiredMessage = () =>
 
 export const getFilenameNotValidMessage = () =>
   "The filename is not valid.";
+
+// sidebar titles
+export const sidebar = {
+  pages: 'Pages',
+  posts: 'Posts',
+  datafiles: 'Data Files',
+  staticfiles: 'Static Files',
+  configuration: 'Configuration'
+};
+
+// button labels
+export const labels = {
+  save: {
+    label: 'Save',
+    triggeredLabel: 'Saved'
+  },
+  create: {
+    label: 'Create',
+    triggeredLabel: 'Created'
+  },
+  delete: {
+    label: 'Delete'
+  },
+  view: {
+    label: 'View'
+  },
+  upload: {
+    label: 'Upload files'
+  }
+};

--- a/src/constants/lang/index.js
+++ b/src/constants/lang/index.js
@@ -1,0 +1,1 @@
+export * from './en'; // TODO: select language

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -6,6 +6,7 @@ import { ADMIN_PREFIX } from '../constants';
 import Splitter from '../components/Splitter';
 import { fetchCollections } from '../actions/collections';
 import { capitalize } from '../utils/helpers';
+import { sidebar } from '../constants/lang';
 import _ from 'underscore';
 
 export class Sidebar extends Component {
@@ -37,21 +38,33 @@ export class Sidebar extends Component {
         <Link className="logo" to={`${ADMIN_PREFIX}/pages`} />
         <ul className="routes">
           <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/pages`}><i className="fa fa-file-text"></i>Pages</Link>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/pages`}>
+              <i className="fa fa-file-text"></i>
+              {sidebar.pages}
+            </Link>
           </li>
 
           {this.renderCollections()}
 
           <Splitter />
           <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/datafiles`}><i className="fa fa-database"></i>Data Files</Link>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/datafiles`}>
+              <i className="fa fa-database"></i>
+              {sidebar.datafiles}
+            </Link>
           </li>
           <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/staticfiles`}><i className="fa fa-file"></i>Static Files</Link>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/staticfiles`}>
+              <i className="fa fa-file"></i>
+              {sidebar.staticfiles}
+            </Link>
           </li>
           <Splitter />
           <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/configuration`}><i className="fa fa-cog"></i>Configuration</Link>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/configuration`}>
+              <i className="fa fa-cog"></i>
+              {sidebar.configuration}
+            </Link>
           </li>
         </ul>
       </div>

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -2,11 +2,11 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
-import _ from 'underscore';
 import { ADMIN_PREFIX } from '../constants';
 import Splitter from '../components/Splitter';
 import { fetchCollections } from '../actions/collections';
 import { capitalize } from '../utils/helpers';
+import _ from 'underscore';
 
 export class Sidebar extends Component {
 
@@ -17,21 +17,18 @@ export class Sidebar extends Component {
 
   renderCollections() {
     const { collections } = this.props;
+
     if (!collections.length) {
       return null;
     }
 
-    return _.chain(collections)
-      .filter(col => col.label != 'posts') // TODO
-      .map((col, i) => {
-        return (
-          <li key={i}>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/${col.label}`}>
-              <i className="fa fa-book"></i>{capitalize(col.label)}
-            </Link>
-          </li>
-        );
-      }).value();
+    return _.map(collections, (col, i) =>
+      <li key={i}>
+        <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/${col.label}`}>
+          <i className="fa fa-book"></i>{capitalize(col.label)}
+        </Link>
+      </li>
+    );
   }
 
   render() {
@@ -42,10 +39,9 @@ export class Sidebar extends Component {
           <li>
             <Link activeClassName="active" to={`${ADMIN_PREFIX}/pages`}><i className="fa fa-file-text"></i>Pages</Link>
           </li>
-          <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/posts`}><i className="fa fa-thumb-tack"></i>Posts</Link>
-          </li>
+
           {this.renderCollections()}
+
           <Splitter />
           <li>
             <Link activeClassName="active" to={`${ADMIN_PREFIX}/datafiles`}><i className="fa fa-database"></i>Data Files</Link>

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -26,7 +26,7 @@ describe('Containers::Sidebar', () => {
   it('should render correctly', () => {
     const { links, component } = setup();
     const actual = links.length;
-    const expected = 5 + component.prop('collections').length;
+    const expected = 4 + component.prop('collections').length;
 
     expect(actual).toEqual(expected);
   });

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 import Editor from '../../components/Editor';
 import Button from '../../components/Button';
 import { putConfig, onEditorChange } from '../../actions/config';
-import { getLeaveMessage } from '../../constants/messages';
+import { getLeaveMessage } from '../../constants/lang';
 import { toYAML } from '../../utils/helpers';
 
 export class Configuration extends Component {

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
 import Editor from '../../components/Editor';
+import Button from '../../components/Button';
 import { putConfig, onEditorChange } from '../../actions/config';
 import { getLeaveMessage } from '../../constants/messages';
 import { toYAML } from '../../utils/helpers';
@@ -20,7 +21,7 @@ export class Configuration extends Component {
     }
   }
 
-  handleSaveClick() {
+  handleClickSave() {
     const { editorChanged, putConfig } = this.props;
     if (editorChanged) {
       const value = this.refs.editor.getValue();
@@ -35,10 +36,11 @@ export class Configuration extends Component {
         <div className="content-header">
           <h1>Configuration</h1>
           <div className="page-buttons">
-            <a className={"btn " + (editorChanged ? 'btn-active':'btn-inactive')}
-              onClick={() => this.handleSaveClick()}>
-                {updated ? 'Saved' : 'Save'}
-            </a>
+            <Button
+              onClick={() => this.handleClickSave()}
+              type="save"
+              active={editorChanged}
+              triggered={updated} />
           </div>
         </div>
         <Editor

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -3,16 +3,20 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
+import Breadcrumbs from '../../components/Breadcrumbs';
 import Splitter from '../../components/Splitter';
+import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
+import Button from '../../components/Button';
 import { clearErrors } from '../../actions/utils';
-import { ADMIN_PREFIX } from '../../constants';
+import { getFilenameFromPath } from '../../utils/helpers';
 import {
   fetchDataFile, putDataFile, deleteDataFile, onDataFileChanged
 } from '../../actions/datafiles';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileEdit extends Component {
 
@@ -61,22 +65,18 @@ export class DataFileEdit extends Component {
       return <h1>{getNotFoundMessage("data file")}</h1>;
     }
 
-    const { slug, ext, raw_content } = datafile;
-    const filename = slug+ext;
+    const { path, raw_content } = datafile;
+    const filename = getFilenameFromPath(path);
 
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
-        <ul className="breadcrumbs">
-          <li><Link to={`${ADMIN_PREFIX}/datafiles`}>Data Files</Link></li>
-          <li>{filename}</li>
-        </ul>
+        <Breadcrumbs
+          link={`${ADMIN_PREFIX}/datafiles`}
+          content={filename}
+          type="datafiles"
+          />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -88,15 +88,20 @@ export class DataFileEdit extends Component {
           </div>
 
           <div className="content-side">
-            <a onClick={() => this.handleClickSave()}
-              className={"btn"+(datafileChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-              {updated ? 'Saved' : 'Save'}
-            </a>
+            <Button
+              onClick={() => this.handleClickSave()}
+              type="save"
+              active={datafileChanged}
+              triggered={updated}
+              icon="save"
+              block />
             <Splitter />
-            <a onClick={() => this.handleClickDelete(filename)}
-              className="side-link delete">
-                <i className="fa fa-trash-o"></i>Delete file
-            </a>
+            <Button
+              onClick={() => this.handleClickDelete(filename)}
+              type="delete"
+              active={true}
+              icon="trash"
+              block />
           </div>
         </div>
       </div>

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -15,7 +15,7 @@ import {
 } from '../../actions/datafiles';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileEdit extends Component {

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -2,15 +2,16 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
-import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
+import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
+import Button from '../../components/Button';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import { putDataFile, onDataFileChanged } from '../../actions/datafiles';
 import { clearErrors } from '../../actions/utils';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileNew extends Component {
 
@@ -50,18 +51,14 @@ export class DataFileNew extends Component {
     const { datafileChanged, onDataFileChanged, datafile, updated, errors } = this.props;
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
         <Breadcrumbs onChange={onDataFileChanged}
           ref="breadcrumbs"
           link={`${ADMIN_PREFIX}/datafiles`}
-          path=""
-          type="data files" />
+          type="datafiles"
+          content=""
+          editable />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -73,13 +70,13 @@ export class DataFileNew extends Component {
           </div>
 
           <div className="content-side">
-            <div className="side-unit">
-              <a onClick={() => this.handleClickSave()}
-                className={"btn"+(datafileChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-                  <i className="fa fa-plus-square" aria-hidden="true"></i>
-                {updated ? 'Created' : 'Create'}
-              </a>
-            </div>
+            <Button
+              onClick={() => this.handleClickSave()}
+              type="create"
+              active={datafileChanged}
+              triggered={updated}
+              icon="plus-square"
+              block />
           </div>
         </div>
       </div>

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -10,7 +10,7 @@ import { putDataFile, onDataFileChanged } from '../../actions/datafiles';
 import { clearErrors } from '../../actions/utils';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileNew extends Component {

--- a/src/containers/views/DataFiles.js
+++ b/src/containers/views/DataFiles.js
@@ -83,7 +83,7 @@ export class DataFiles extends Component {
           <div className="page-buttons">
             <Link className="btn btn-active" to={`${ADMIN_PREFIX}/datafiles/new`}>New data file</Link>
           </div>
-          <div className="side-unit pull-right">
+          <div className="pull-right">
             <InputSearch searchBy="filename" search={search} />
           </div>
         </div>

--- a/src/containers/views/DataFiles.js
+++ b/src/containers/views/DataFiles.js
@@ -3,12 +3,13 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
 import { getDeleteMessage, getNotFoundMessage } from '../../constants/messages';
 import InputSearch from '../../components/form/InputSearch';
+import Button from '../../components/Button';
 import { fetchDataFiles, deleteDataFile } from '../../actions/datafiles';
 import { search } from '../../actions/utils';
 import { filterByFilename } from '../../reducers/datafiles';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFiles extends Component {
 
@@ -55,9 +56,12 @@ export class DataFiles extends Component {
           </td>
           <td>
             <div className="row-actions">
-              <a onClick={() => this.handleClickDelete(filename)} title="Delete" className="delete">
-                <i className="fa fa-trash-o" aria-hidden="true"></i> Delete
-              </a>
+              <Button
+                onClick={() => this.handleClickDelete(filename)}
+                type="delete"
+                icon="trash"
+                active={true}
+                thin />
             </div>
           </td>
         </tr>

--- a/src/containers/views/DataFiles.js
+++ b/src/containers/views/DataFiles.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import _ from 'underscore';
-import { getDeleteMessage, getNotFoundMessage } from '../../constants/messages';
+import { getDeleteMessage, getNotFoundMessage } from '../../constants/lang';
 import InputSearch from '../../components/form/InputSearch';
 import Button from '../../components/Button';
 import { fetchDataFiles, deleteDataFile } from '../../actions/datafiles';

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -3,19 +3,21 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
 import Splitter from '../../components/Splitter';
+import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import Button from '../../components/Button';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import Metadata from '../../containers/MetaFields';
 import { fetchDocument, deleteDocument, putDocument } from '../../actions/collections';
-import { updateTitle, updateBody, updatePath, updateDraft } from '../../actions/metadata';
+import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
 import { clearErrors } from '../../actions/utils';
 import { getFilenameFromPath } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentEdit extends Component {
 
@@ -67,8 +69,10 @@ export class DocumentEdit extends Component {
   }
 
   render() {
-    const { isFetching, currentDocument, errors, updateTitle, updateBody, updatePath,
-      updateDraft, updated, fieldChanged } = this.props;
+    const {
+      isFetching, currentDocument, errors, updateTitle, updateBody, updatePath, updated,
+      fieldChanged
+    } = this.props;
 
     if (isFetching) {
       return null;
@@ -84,18 +88,14 @@ export class DocumentEdit extends Component {
 
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
-        <Breadcrumbs onChange={updatePath}
-          ref="breadcrumbs"
+        <Breadcrumbs
+          onChange={updatePath}
           link={`${ADMIN_PREFIX}/collections/${collection}`}
-          path={path}
-          type={collection} />
+          content={path}
+          type={collection}
+          editable />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -111,27 +111,30 @@ export class DocumentEdit extends Component {
           </div>
 
           <div className="content-side">
-            <div className="side-unit">
-              <a onClick={() => this.handleClickSave(filename, collection)}
-                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-                  <i className="fa fa-save" aria-hidden="true"></i>
-                {updated ? 'Saved' : 'Save'}
-              </a>
-            </div>
+            <Button
+              onClick={() => this.handleClickSave(filename, collection)}
+              type="save"
+              active={fieldChanged}
+              triggered={updated}
+              icon="save"
+              block />
             {
-              http_url && <div className="side-unit">
-                <Link target="_blank" className="btn btn-fat" to={http_url}>
-                  <i className="fa fa-eye" aria-hidden="true"></i>View
-                </Link>
-              </div>
+              http_url &&
+                <Button
+                  to={http_url}
+                  type="view"
+                  icon="eye"
+                  active={true}
+                  block />
             }
             <Splitter />
-            <a onClick={() => this.handleClickDelete(filename, collection)}
-              className="side-link delete">
-                <i className="fa fa-trash-o"></i>Delete document
-            </a>
+            <Button
+              onClick={() => this.handleClickDelete(filename, collection)}
+              type="delete"
+              active={true}
+              icon="trash"
+              block />
           </div>
-
         </div>
       </div>
     );
@@ -146,7 +149,6 @@ DocumentEdit.propTypes = {
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
-  updateDraft: PropTypes.func.isRequired,
   clearErrors: PropTypes.func.isRequired,
   isFetching: PropTypes.bool.isRequired,
   errors: PropTypes.array.isRequired,
@@ -172,7 +174,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   updateTitle,
   updateBody,
   updatePath,
-  updateDraft,
   clearErrors
 }, dispatch);
 

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -16,7 +16,7 @@ import { clearErrors } from '../../actions/utils';
 import { getFilenameFromPath } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentEdit extends Component {

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -15,7 +15,7 @@ import { clearErrors } from '../../actions/utils';
 import { getFilenameFromPath } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentNew extends Component {

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -2,20 +2,21 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
-import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
 import Splitter from '../../components/Splitter';
+import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import Button from '../../components/Button';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import Metadata from '../../containers/MetaFields';
-import { updateTitle, updateBody, updatePath, updateDraft } from '../../actions/metadata';
+import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
 import { putDocument } from '../../actions/collections';
 import { clearErrors } from '../../actions/utils';
 import { getFilenameFromPath } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentNew extends Component {
 
@@ -53,28 +54,21 @@ export class DocumentNew extends Component {
   }
 
   render() {
-    const { errors, updated, updateTitle, updateBody, updatePath,
-      updateDraft, fieldChanged, params } = this.props;
+    const { errors, updated, updateTitle, updateBody, updatePath, fieldChanged, params } = this.props;
 
-    const link = `${ADMIN_PREFIX}/collections/${params.collection_name}`;
-    const linkText = params.collection_name;
-    const type = params.collection_name;
+    const collection = params.collection_name;
+    const link = `${ADMIN_PREFIX}/collections/${collection}`;
 
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
-        <Breadcrumbs onChange={updatePath}
-          ref="breadcrumbs"
+        <Breadcrumbs
+          onChange={updatePath}
           link={link}
-          linkText={linkText}
-          type={type}
-          path="" />
+          type={collection}
+          content=""
+          editable />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -90,13 +84,13 @@ export class DocumentNew extends Component {
           </div>
 
           <div className="content-side">
-            <div className="side-unit">
-              <a onClick={() => this.handleClickSave()}
-                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-                  <i className="fa fa-plus-square" aria-hidden="true"></i>
-                {updated ? 'Created' : 'Create'}
-              </a>
-            </div>
+            <Button
+              onClick={() => this.handleClickSave()}
+              type="create"
+              active={fieldChanged}
+              triggered={updated}
+              icon="plus-square"
+              block />
           </div>
 
         </div>
@@ -110,7 +104,6 @@ DocumentNew.propTypes = {
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
-  updateDraft: PropTypes.func.isRequired,
   clearErrors: PropTypes.func.isRequired,
   errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
@@ -131,7 +124,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   updateTitle,
   updateBody,
   updatePath,
-  updateDraft,
   putDocument,
   clearErrors
 }, dispatch);

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -116,7 +116,7 @@ export class Documents extends Component {
               {collection_name == "posts" ? "New post" : "New document"}
             </Link>
           </div>
-          <div className="side-unit pull-right">
+          <div className="pull-right">
             <InputSearch searchBy="title" search={search} />
           </div>
         </div>

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -14,7 +14,7 @@ import {
   getLeaveMessage,
   getDeleteMessage,
   getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class Documents extends Component {

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -5,16 +5,17 @@ import { bindActionCreators } from 'redux';
 import _ from 'underscore';
 import moment from 'moment';
 import InputSearch from '../../components/form/InputSearch';
+import Button from '../../components/Button';
 import { fetchCollection, deleteDocument } from '../../actions/collections';
 import { filterByTitle } from '../../reducers/collections';
 import { capitalize, getFilenameFromPath } from '../../utils/helpers';
 import { search } from '../../actions/utils';
-import { ADMIN_PREFIX } from '../../constants';
 import {
   getLeaveMessage,
   getDeleteMessage,
   getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class Documents extends Component {
 
@@ -76,13 +77,20 @@ export class Documents extends Component {
           <td>{date}</td>
           <td>
             <div className="row-actions">
-              <a onClick={() => this.handleClickDelete(filename, collection)} title="Delete" className="delete">
-                <i className="fa fa-trash-o" aria-hidden="true"></i> Delete
-              </a>
+              <Button
+                onClick={() => this.handleClickDelete(filename, collection)}
+                type="delete"
+                icon="trash"
+                active={true}
+                thin />
               {
-                http_url && <a target="_blank" href={http_url} title="View" className="view">
-                  <i className="fa fa-eye" aria-hidden="true"></i> View
-                </a>
+                http_url &&
+                <Button
+                  to={http_url}
+                  type="view"
+                  icon="eye"
+                  active={true}
+                  thin />
               }
             </div>
           </td>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -3,8 +3,9 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
+import Button from '../../components/Button';
 import Splitter from '../../components/Splitter';
+import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
@@ -15,6 +16,7 @@ import { clearErrors } from '../../actions/utils';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class PageEdit extends Component {
 
@@ -79,18 +81,14 @@ export class PageEdit extends Component {
 
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
-        <Breadcrumbs onChange={updatePath}
-          path={path}
-          ref="breadcrumbs"
+        <Breadcrumbs
+          onChange={updatePath}
+          content={path}
           link={`${ADMIN_PREFIX}/pages`}
-          type="pages" />
+          type="pages"
+          editable />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -106,23 +104,26 @@ export class PageEdit extends Component {
           </div>
 
           <div className="content-side">
-            <div className="side-unit">
-              <a onClick={() => this.handleClickSave(name)}
-                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-                  <i className="fa fa-save" aria-hidden="true"></i>
-                {updated ? 'Saved' : 'Save'}
-              </a>
-            </div>
-            <div className="side-unit">
-              <Link target="_blank" className="btn btn-fat" to={http_url}>
-                <i className="fa fa-eye" aria-hidden="true"></i>View
-              </Link>
-            </div>
+            <Button
+              onClick={() => this.handleClickSave(name)}
+              type="save"
+              active={fieldChanged}
+              triggered={updated}
+              icon="save"
+              block />
+            <Button
+              to={http_url}
+              type="view"
+              icon="eye"
+              active={true}
+              block />
             <Splitter />
-            <a onClick={() => this.handleClickDelete(name)}
-              className="side-link delete">
-                <i className="fa fa-trash-o"></i>Delete page
-            </a>
+            <Button
+              onClick={() => this.handleClickDelete(name)}
+              type="delete"
+              active={true}
+              icon="trash"
+              block />
           </div>
 
         </div>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -15,7 +15,7 @@ import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
 import { clearErrors } from '../../actions/utils';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class PageEdit extends Component {

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -16,7 +16,7 @@ import { putPage } from '../../actions/pages';
 import { clearErrors } from '../../actions/utils';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 
 export class PageNew extends Component {
 

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -2,10 +2,11 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
-import _ from 'underscore';
 import { ADMIN_PREFIX } from '../../constants';
 import Splitter from '../../components/Splitter';
+import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import Button from '../../components/Button';
 import InputTitle from '../../components/form/InputTitle';
 import Checkbox from '../../components/form/Checkbox';
 import MarkdownEditor from '../../components/MarkdownEditor';
@@ -54,19 +55,14 @@ export class PageNew extends Component {
 
     return (
       <div>
-        {
-          errors.length > 0 &&
-          <ul className="error-messages">
-            {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-          </ul>
-        }
+        {errors.length > 0 && <Errors errors={errors} />}
 
-        <Breadcrumbs onChange={updatePath}
-          ref="breadcrumbs"
+        <Breadcrumbs
+          onChange={updatePath}
           link={`${ADMIN_PREFIX}/pages`}
-          linkText={"Pages"}
           type={"pages"}
-          path="" />
+          content=""
+          editable />
 
         <div className="content-wrapper">
           <div className="content-body">
@@ -82,13 +78,13 @@ export class PageNew extends Component {
           </div>
 
           <div className="content-side">
-            <div className="side-unit">
-              <a onClick={() => this.handleClickSave()}
-                className={"btn"+(fieldChanged ? " btn-success " : " btn-inactive ")+"btn-fat"}>
-                  <i className="fa fa-plus-square" aria-hidden="true"></i>
-                {updated ? 'Created' : 'Create'}
-              </a>
-            </div>
+            <Button
+              onClick={() => this.handleClickSave()}
+              type="create"
+              active={fieldChanged}
+              triggered={updated}
+              icon="plus-square"
+              block />
           </div>
 
         </div>

--- a/src/containers/views/Pages.js
+++ b/src/containers/views/Pages.js
@@ -10,7 +10,7 @@ import { search } from '../../actions/utils';
 import { filterByFilename } from '../../reducers/pages';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
-} from '../../constants/messages';
+} from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class Pages extends Component {

--- a/src/containers/views/Pages.js
+++ b/src/containers/views/Pages.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import _ from 'underscore';
-import { ADMIN_PREFIX } from '../../constants';
+import Button from '../../components/Button';
 import InputSearch from '../../components/form/InputSearch';
 import { fetchPages, deletePage } from '../../actions/pages';
 import { search } from '../../actions/utils';
@@ -11,6 +11,7 @@ import { filterByFilename } from '../../reducers/pages';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/messages';
+import { ADMIN_PREFIX } from '../../constants';
 
 export class Pages extends Component {
 
@@ -57,12 +58,18 @@ export class Pages extends Component {
           </td>
           <td>
             <div className="row-actions">
-              <a onClick={() => this.handleClickDelete(name)} title="Delete" className="delete">
-                <i className="fa fa-trash-o" aria-hidden="true"></i> Delete
-              </a>
-              <a target="_blank" href={http_url} title="View" className="view">
-                <i className="fa fa-eye" aria-hidden="true"></i> View
-              </a>
+              <Button
+                onClick={() => this.handleClickDelete(name)}
+                type="delete"
+                icon="trash"
+                active={true}
+                thin />
+              <Button
+                to={http_url}
+                type="view"
+                icon="eye"
+                active={true}
+                thin />
             </div>
           </td>
         </tr>

--- a/src/containers/views/Pages.js
+++ b/src/containers/views/Pages.js
@@ -91,7 +91,7 @@ export class Pages extends Component {
           <div className="page-buttons">
             <Link className="btn btn-active" to={`${ADMIN_PREFIX}/pages/new`}>New page</Link>
           </div>
-          <div className="side-unit pull-right">
+          <div className="pull-right">
             <InputSearch searchBy="filename" search={search} />
           </div>
         </div>

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import _ from 'underscore';
 import { ADMIN_PREFIX } from '../../constants';
 import Dropzone from 'react-dropzone';
+import Button from '../../components/Button';
 import FilePreview from '../../components/FilePreview';
 import InputSearch from '../../components/form/InputSearch';
 import { search } from '../../actions/utils';
@@ -80,9 +81,11 @@ export class StaticFiles extends Component {
       <div>
         <div className="content-header">
           <h1>Static Files</h1>
-          <a onClick={() => this.openDropzone()} className="btn btn-active">
-            <i className="fa fa-upload" aria-hidden="true"></i> Upload files
-          </a>
+          <Button
+            onClick={() => this.openDropzone()}
+            type="upload"
+            icon="upload"
+            active={true} />
           <div className="side-unit pull-right">
             <InputSearch searchBy="filename" search={search} />
           </div>

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -86,7 +86,7 @@ export class StaticFiles extends Component {
             type="upload"
             icon="upload"
             active={true} />
-          <div className="side-unit pull-right">
+          <div className="pull-right">
             <InputSearch searchBy="filename" search={search} />
           </div>
         </div>

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -11,7 +11,7 @@ import InputSearch from '../../components/form/InputSearch';
 import { search } from '../../actions/utils';
 import { existingUploadedFilenames } from '../../utils/helpers.js';
 import { filterByFilename } from '../../reducers/staticfiles';
-import { getOverrideMessage } from '../../constants/messages';
+import { getOverrideMessage } from '../../constants/lang';
 import {
   fetchStaticFiles, uploadStaticFiles, deleteStaticFile
 } from '../../actions/staticfiles';

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import expect from 'expect';
 import Editor from '../../../components/Editor';
+import Button from '../../../components/Button';
 import { Configuration } from '../Configuration';
 import { toYAML } from '../../../utils/helpers';
 import { config } from './fixtures';
@@ -20,18 +21,17 @@ const setup = (props = defaultProps) => {
   const component = shallow(<Configuration {...props} />);
   return {
     component,
-    props,
     editor: component.find(Editor),
-    saveButton: component.find('a')
+    saveButton: component.find(Button)
   };
 };
 
 describe('Containers::Configuration', () => {
   it('should render correctly with initial props', () => {
     const { component, editor, saveButton } = setup();
-    expect(saveButton.text()).toBe('Save');
-    expect(saveButton.prop('className').trim()).toBe('btn btn-inactive');
     expect(editor.prop('content')).toEqual(toYAML(config));
+    expect(saveButton.prop('active')).toBe(false);
+    expect(saveButton.prop('triggered')).toBe(false);
   });
 
   it('should render correctly with updated props', () => {
@@ -41,7 +41,7 @@ describe('Containers::Configuration', () => {
         updated: true
       })
     );
-    expect(saveButton.text()).toBe('Saved');
-    expect(saveButton.prop('className').trim()).toBe('btn btn-active');
+    expect(saveButton.prop('triggered')).toBe(true);
+    expect(saveButton.prop('active')).toBe(true);
   });
 });

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -5,6 +5,8 @@ import expect from 'expect';
 
 import { DataFileNew } from '../DataFileNew';
 
+import Button from '../../../components/Button';
+
 const defaultProps = {
   datafile: {},
   updated: false,
@@ -27,7 +29,7 @@ const setup = (props = defaultProps) => {
   return {
     component,
     actions,
-    saveButton: component.find('.content-side a').first(),
+    saveButton: component.find(Button),
     props
   };
 };
@@ -43,6 +45,6 @@ describe('Containers::DataFileNew', () => {
     const { saveButton, actions } = setup(Object.assign({}, defaultProps, {
       datafileChanged: true
     }));
-    expect(saveButton.prop('className')).toMatch('btn-success');
+    expect(saveButton.prop('active')).toBe(true);
   });
 });

--- a/src/containers/views/tests/documentedit.spec.js
+++ b/src/containers/views/tests/documentedit.spec.js
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import expect from 'expect';
 
 import { DocumentEdit } from '../DocumentEdit';
+import Errors from '../../../components/Errors';
+import Button from '../../../components/Button';
 
 import { doc } from './fixtures';
 
@@ -26,7 +28,6 @@ const setup = (props = defaultProps) => {
     updateTitle: expect.createSpy(),
     updateBody: expect.createSpy(),
     updatePath: expect.createSpy(),
-    updateDraft: expect.createSpy(),
     clearErrors: expect.createSpy()
   };
 
@@ -35,9 +36,9 @@ const setup = (props = defaultProps) => {
   return {
     component,
     actions,
-    saveButton: component.find('.content-side a').first(),
-    deleteButton: component.find('.content-side .delete'),
-    errors: component.find('.error-messages'),
+    saveButton: component.find(Button).first(),
+    deleteButton: component.find(Button).last(),
+    errors: component.find(Errors),
     props
   };
 };

--- a/src/containers/views/tests/documentnew.spec.js
+++ b/src/containers/views/tests/documentnew.spec.js
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import expect from 'expect';
 
 import { DocumentNew } from '../DocumentNew';
+import Errors from '../../../components/Errors';
+import Button from '../../../components/Button';
 
 import { doc } from './fixtures';
 
@@ -22,7 +24,6 @@ const setup = (props = defaultProps) => {
     updateTitle: expect.createSpy(),
     updateBody: expect.createSpy(),
     updatePath: expect.createSpy(),
-    updateDraft: expect.createSpy(),
     clearErrors: expect.createSpy()
   };
 
@@ -31,8 +32,8 @@ const setup = (props = defaultProps) => {
   return {
     component,
     actions,
-    saveButton: component.find('.content-side a'),
-    errors: component.find('.error-messages'),
+    saveButton: component.find(Button),
+    errors: component.find(Errors),
     props
   };
 };

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import expect from 'expect';
 
 import { PageEdit } from '../PageEdit';
+import Errors from '../../../components/Errors';
+import Button from '../../../components/Button';
 
 import { page } from './fixtures';
 
@@ -35,9 +37,9 @@ const setup = (props = defaultProps) => {
   return {
     component,
     actions,
-    saveButton: component.find('.content-side a').first(),
-    deleteButton: component.find('.content-side .delete'),
-    errors: component.find('.error-messages'),
+    saveButton: component.find(Button).first(),
+    deleteButton: component.find(Button).last(),
+    errors: component.find(Errors),
     props
   };
 };

--- a/src/containers/views/tests/pagenew.spec.js
+++ b/src/containers/views/tests/pagenew.spec.js
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import expect from 'expect';
 
 import { PageNew } from '../PageNew';
+import Errors from '../../../components/Errors';
+import Button from '../../../components/Button';
 
 import { page } from './fixtures';
 
@@ -32,8 +34,8 @@ function setup(props = defaultProps) {
   return {
     component,
     actions,
-    saveButton: component.find('.content-side a'),
-    errors: component.find('.error-messages'),
+    saveButton: component.find(Button),
+    errors: component.find(Errors),
     props
   };
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Jekyll Admin</title>
-    <link rel="shortcut icon" href="favicon.ico">
+    <link rel="shortcut icon" href="/admin/favicon.ico">
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import routes from './routes';
 import configureStore from './store/configureStore';
 import { ADMIN_PREFIX } from './constants';
 import './styles/main.scss';
+import './assets/favicon.ico';
 
 const store = configureStore();
 const history = syncHistoryWithStore(browserHistory, store);

--- a/src/styles/breadcrumbs.scss
+++ b/src/styles/breadcrumbs.scss
@@ -1,6 +1,3 @@
-@import 'mixins';
-@import 'variables';
-
 .breadcrumbs {
   display: flex;
   align-items: center;

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -1,0 +1,60 @@
+.btn {
+  color: $off-white;
+  font-weight: bold;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  margin: 0;
+  padding: 12px 20px;
+  white-space: nowrap;
+  text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.2);
+  @include border-radius($border-radius);
+  @include box-sizing(border-box);
+  @include btn($btn-initial, $btn-initial-border);
+  i {
+    margin-right: 4px;
+  }
+}
+
+.btn-fat {
+  margin: 10px 0;
+  width: 100%;
+  text-align: center;
+}
+
+.btn-thin {
+  padding: 8px;
+  margin: 5px;
+}
+
+.btn-active {
+  @include btn($btn-active, $btn-active-border);
+}
+
+.btn-inactive {
+  @include btn($btn-inactive, $btn-inactive-border, default !important, .5 !important, false);
+}
+
+.btn-success {
+  @include btn($btn-success, $btn-success-border, pointer);
+  &:hover {
+    background-color: lighten($btn-success, 5%) !important;
+    @include box-shadow(0 1px 0 $btn-success-border);
+  }
+}
+
+.btn-delete {
+  @include btn($btn-initial, $btn-initial-border);
+  @include transition(background 0.3s);
+  &:hover {
+    @include btn($dark-red, $btn-danger-border);
+  }
+}
+
+.btn-view {
+  @include btn($btn-initial, $btn-initial-border);
+  @include transition(background 0.3s);
+  &:hover {
+    @include btn($btn-active, $btn-active-border);
+  }
+}

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -81,28 +81,6 @@
     float: right;
     min-width: 96px;
     font-size: 16px;
-    a {
-      display: inline-block;
-      margin: 5px;
-      padding: 8px;
-      color: $off-white;
-      background: $inactive-gray;
-      @include border-radius($border-radius);
-      &:hover {
-        color: $orange;
-      }
-      &.delete:hover {
-        color: $white !important;
-        background: $dark-red;
-      }
-      &.view:hover {
-        color: $white !important;
-        background: $green;
-      }
-    }
-    i {
-      margin-right: 4px;
-    }
   }
 }
 
@@ -160,16 +138,6 @@
       .side-link.options {
         color: $dark-orange;
       }
-      .side-link.delete {
-        color: $off-white;
-        background: $inactive-gray;
-        border: 0;
-        @include transition(background 0.3s ease);
-        &:hover {
-          color: $white;
-          background-color: $dark-red;
-        }
-      }
     }
   }
   .error-messages {
@@ -188,8 +156,8 @@
   }
 
   .tooltip {
-    position: relative; 
-    
+    position: relative;
+
     .tooltip-text {
       display: none;
       position: absolute;
@@ -218,4 +186,3 @@
     }
   }
 }
-

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -1,6 +1,3 @@
-@import 'mixins';
-@import 'variables';
-
 .config-editor {
   border: 1px solid $border-color;
   @include border-radius($border-radius);

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -1,6 +1,3 @@
-@import 'mixins';
-@import 'variables';
-
 .field {
   background-color: #fff;
   color: #555;

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -1,5 +1,3 @@
-@import 'mixins';
-
 .header {
   display: flex;
   align-items: center;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -10,6 +10,7 @@
 @import 'metafields';
 @import 'breadcrumbs';
 @import "editor";
+@import "button";
 @import "staticfiles";
 
 * {
@@ -54,54 +55,10 @@ i {
   margin-left: $sidebar-width;
 }
 
-.btn {
-  color: $off-white;
-  font-weight: bold;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 14px;
-  margin: 0;
-  padding: 12px 20px;
-  white-space: nowrap;
-  text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.2);
-  @include border-radius($border-radius);
-  @include box-sizing(border-box);
-  @include btn($btn-initial, $btn-initial-border);
-}
-
-.btn-fat {
-  margin: 10px 0;
-  width: 100%;
-  text-align: center;
-  &:hover {
-    @include btn($btn-fat-hover, $btn-fat-hover-border)
-  }
-}
-
-.btn-active {
-  @include btn($btn-active, $btn-active-border);
-}
-
-.btn-inactive {
-  @include btn($btn-inactive, $btn-inactive-border, default !important, .5 !important, false); 
-}
-
-.btn-success {
-  @include btn($btn-success, $btn-success-border, pointer);
-  &:hover {
-    background-color: lighten($btn-success, 5%) !important;
-    @include box-shadow(0 1px 0 $btn-success-border);
-  }
-}
-
-.btn-danger {
-  @include btn($btn-danger, $btn-danger-border);
-}
-
 .splitter {
   height: 1px;
   width: 100%;
-  margin: 5px 0;  
+  margin: 5px 0;
   border-bottom: 1px solid #424242;
   border-top: 1px solid #212121;
 }

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -159,19 +159,18 @@
       .dropdown {
         cursor: pointer;
         position: relative;
-        button {
+        .meta-button {
           border: 2px solid #d4d7d9;
-          background: none;
-          padding: 0;
+          padding: 3px 0;
           @include border-radius(50%);
           &:hover, &:focus {
             border-color: $dark-orange;
             background: $dark-orange;
             color: #fff;
           }
-        }
-        button:focus + .dropdown-wrap {
-          display: block;
+          &:focus + .dropdown-wrap {
+            display: block;
+          }
         }
         .dropdown-wrap {
           &:before {

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -136,21 +136,8 @@
       top: 4px;
       right: 0;
       z-index: 8;
-      .meta-button {
-        color: #9098A3;
-        font-size: 13px;
-        width: 23px;
-        height: 23px;
-        line-height: 1;
-        border-radius: 50%;
-        display: inline-block;
-        text-align: center;
-        outline: 0;
-        i {
-          margin: 0;
-        }
-      }
-      .meta-button.move {
+      span.move {
+        color: $inactive-gray;
         cursor: move;
         &:hover, &:focus {
           color: $dark-orange;
@@ -161,7 +148,14 @@
         position: relative;
         .meta-button {
           border: 2px solid #d4d7d9;
-          padding: 3px 0;
+          padding: 2px 0;
+          color: $inactive-gray;
+          font-size: 13px;
+          width: 23px;
+          height: 23px;
+          display: inline-block;
+          text-align: center;
+          outline: none;
           @include border-radius(50%);
           &:hover, &:focus {
             border-color: $dark-orange;
@@ -170,6 +164,9 @@
           }
           &:focus + .dropdown-wrap {
             display: block;
+          }
+          i {
+            margin: 0;
           }
         }
         .dropdown-wrap {

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -1,5 +1,3 @@
-@import 'variables';
-
 .sidebar{
   position: fixed;
   top: 0;

--- a/src/styles/staticfiles.scss
+++ b/src/styles/staticfiles.scss
@@ -1,5 +1,3 @@
-@import 'variables';
-
 .dropzone {
   text-align: center;
   padding: 20px;

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -5,7 +5,7 @@ import {
   getFetchErrorMessage,
   getUpdateErrorMessage,
   getDeleteMessage
-} from '../constants/messages';
+} from '../constants/lang';
 
 /**
  * Fetch wrapper for GET request that dispatches actions according to the

--- a/yarn.lock
+++ b/yarn.lock
@@ -3829,7 +3829,7 @@ mocha@2.4.5:
     mkdirp "0.5.1"
     supports-color "1.2.0"
 
-moment@^2.13.0:
+moment@^2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 


### PR DESCRIPTION
This PR mostly aims at code refactoring by creating React components that are reused within the containers.

##  New components
- [Button](https://github.com/jekyll/jekyll-admin/blob/12ffdd1ca8f37b91d7c3afadb6b789420b7af1de/src/components/Button.js): This is a generic component for button elements across the front end. It's responsible for generating button types like `create`, `update`, `view`, `delete` and so on.

- [Errors](https://github.com/jekyll/jekyll-admin/blob/12ffdd1ca8f37b91d7c3afadb6b789420b7af1de/src/components/Errors.js): This one is for displaying validation error messages. It was copy-pasted into a bunch of places before. Making it a component is a good practise.

## Updated Components

- [Breadcrumbs](https://github.com/jekyll/jekyll-admin/blob/12ffdd1ca8f37b91d7c3afadb6b789420b7af1de/src/components/Breadcrumbs.js): Made it a bit more generic to support Data Files since we don't allow changing their filenames, thus their breadcrumbs do not have input field. So adding an `editable` option to the component will allow us to choose whether it should be an input or just a label.

## Localization (One more step to #99)

- To cover all language specific strings, created `lang` folder which contains the files of available languages (only `en.js` for now) and `index.js` file which exports the selected language strings (default to `en` for now).
- `Sidebar` titles and `Button` labels are now imported from `lang` 

##  Other changes

- Removed extra imports such as `brace` import [here](https://github.com/jekyll/jekyll-admin/compare/abstraction?expand=1#diff-4e3a9db16091b30733c3987ad2e4d949L2) which saves us ~300kb in `bundle.js` and some sass imports that have no impact on the front-end style.

- Fixed the issue on Firefox and Safari that the metafield dropdown is not working due to the difference between the behavior of `:focus` css attribute for buttons.

- Finally added Jekyll favicon 🎉 