### PR TITLE
Fix invalid ref prop for InputPath

### DIFF
--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -28,7 +28,7 @@ export class DataFileNew extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
-      const filename = this.refs.breadcrumbs.refs.input.value;
+      const filename = this.refs.inputpath.refs.input.value;
       browserHistory.push(`${ADMIN_PREFIX}/datafiles/${filename}`);
     }
   }
@@ -42,7 +42,7 @@ export class DataFileNew extends Component {
   handleClickSave() {
     const { datafileChanged, putDataFile } = this.props;
     if (datafileChanged) {
-      const filename = this.refs.breadcrumbs.refs.input.value;
+      const filename = this.refs.inputpath.refs.input.value;
       const value = this.refs.editor.getValue();
       putDataFile(filename, value);
     }
@@ -63,7 +63,7 @@ export class DataFileNew extends Component {
               onChange={onDataFileChanged}
               type="datafiles"
               path=""
-              ref="input" />
+              ref="inputpath" />
             <Editor
               editorChanged={datafileChanged}
               onEditorChange={onDataFileChanged}

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -109,7 +109,7 @@ export class DocumentEdit extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type={collection} path={name} ref="input" />
+            <InputPath onChange={updatePath} type={collection} path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
             <MarkdownEditor
               onChange={updateBody}

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -72,7 +72,7 @@ export class DocumentNew extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type={collection} path="" ref="input" />
+            <InputPath onChange={updatePath} type={collection} path="" />
             <InputTitle onChange={updateTitle} title="" ref="title" />
             <MarkdownEditor
               onChange={updateBody}

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -96,7 +96,7 @@ export class PageEdit extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type="pages" path={name} ref="input" />
+            <InputPath onChange={updatePath} type="pages" path={name} />
             <InputTitle onChange={updateTitle} title={title} ref="title" />
             <MarkdownEditor
               onChange={updateBody}

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -65,7 +65,7 @@ export class PageNew extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath onChange={updatePath} type="pages" path="" ref="input" />
+            <InputPath onChange={updatePath} type="pages" path="" />
             <InputTitle onChange={updateTitle} title="" ref="title" />
             <MarkdownEditor
               onChange={updateBody}


### PR DESCRIPTION
#281 PR introduces a new React component `InputPath`. Somehow, I missed changing its ref name. This was preventing creating new datafiles.