### PR TITLE
Clear errors before unmounting

### DIFF
--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -20,15 +20,18 @@ import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileEdit extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { fetchDataFile, params, router, route } = this.props;
     router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
     fetchDataFile(params.data_file);
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
+    }
   }
 
   routerWillLeave(nextLocation) {

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -58,7 +58,10 @@ export class DataFileEdit extends Component {
   }
 
   render() {
-    const { datafileChanged, onDataFileChanged, datafile, isFetching, updated, errors, params } = this.props;
+    const {
+      datafileChanged, onDataFileChanged, datafile, isFetching,
+      updated, errors, params
+    } = this.props;
 
     if (isFetching) {
       return null;
@@ -141,4 +144,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearErrors
 }, dispatch);
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DataFileEdit));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(DataFileEdit)
+);

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -16,11 +16,6 @@ import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileNew extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { router, route } = this.props;
     router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
@@ -30,6 +25,14 @@ export class DataFileNew extends Component {
     if (this.props.updated !== nextProps.updated) {
       const filename = this.refs.inputpath.refs.input.value;
       browserHistory.push(`${ADMIN_PREFIX}/datafiles/${filename}`);
+    }
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
     }
   }
 
@@ -49,7 +52,10 @@ export class DataFileNew extends Component {
   }
 
   render() {
-    const { datafileChanged, onDataFileChanged, datafile, updated, errors } = this.props;
+    const {
+      datafileChanged, onDataFileChanged, datafile, updated, errors
+    } = this.props;
+
     return (
       <div>
         {errors.length > 0 && <Errors errors={errors} />}
@@ -111,4 +117,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearErrors
 }, dispatch);
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DataFileNew));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(DataFileNew)
+);

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -21,11 +21,6 @@ import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentEdit extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { fetchDocument, params, router, route } = this.props;
     const [directory, ...rest] = params.splat;
@@ -46,6 +41,14 @@ export class DocumentEdit extends Component {
           `${ADMIN_PREFIX}/collections/${new_path.substring(1)}` // remove `_`
         );
       }
+    }
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
     }
   }
 

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -191,4 +191,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearErrors
 }, dispatch);
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DocumentEdit));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(DocumentEdit)
+);

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -59,7 +59,9 @@ export class DocumentNew extends Component {
   }
 
   render() {
-    const { errors, updated, updateTitle, updateBody, updatePath, fieldChanged, params } = this.props;
+    const {
+      errors, updated, updateTitle, updateBody, updatePath, fieldChanged, params
+    } = this.props;
 
     const collection = params.collection_name;
     const link = `${ADMIN_PREFIX}/collections/${collection}`;
@@ -131,4 +133,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearErrors
 }, dispatch);
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(DocumentNew));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(DocumentNew)
+);

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -21,11 +21,6 @@ import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentNew extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { router, route } = this.props;
     router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
@@ -38,6 +33,14 @@ export class DocumentNew extends Component {
       browserHistory.push(
         `${ADMIN_PREFIX}/collections/${nextProps.currentDocument.collection}/${splat}`
       );
+    }
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
     }
   }
 

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -21,11 +21,6 @@ import { ADMIN_PREFIX } from '../../constants';
 
 export class PageEdit extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { fetchPage, params, router, route } = this.props;
     const [directory, ...rest] = params.splat;
@@ -43,6 +38,14 @@ export class PageEdit extends Component {
       if (new_path != path) {
         browserHistory.push(`${ADMIN_PREFIX}/pages/${new_path}`);
       }
+    }
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
     }
   }
 

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -21,11 +21,6 @@ import {
 
 export class PageNew extends Component {
 
-  componentWillMount() {
-    const { clearErrors } = this.props;
-    clearErrors();
-  }
-
   componentDidMount() {
     const { router, route } = this.props;
     router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
@@ -34,6 +29,14 @@ export class PageNew extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       browserHistory.push(`${ADMIN_PREFIX}/pages/${nextProps.page.path}`);
+    }
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors} = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
     }
   }
 

--- a/src/containers/views/tests/documentedit.spec.js
+++ b/src/containers/views/tests/documentedit.spec.js
@@ -44,11 +44,6 @@ const setup = (props = defaultProps) => {
 };
 
 describe('Containers::DocumentEdit', () => {
-  it('should call clearErrors before mount', () => {
-    const { actions } = setup();
-    expect(actions.clearErrors).toHaveBeenCalled();
-  });
-
   it('should render correctly', () => {
     let { component } = setup(Object.assign(
       {}, defaultProps, { isFetching: true }

--- a/src/containers/views/tests/documentnew.spec.js
+++ b/src/containers/views/tests/documentnew.spec.js
@@ -39,11 +39,6 @@ const setup = (props = defaultProps) => {
 };
 
 describe('Containers::DocumentNew', () => {
-  it('should call clearErrors before mount', () => {
-    const { actions } = setup();
-    expect(actions.clearErrors).toHaveBeenCalled();
-  });
-
   it('should not render error messages initially', () => {
     const { errors } = setup();
     expect(errors.node).toNotExist();

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -45,11 +45,6 @@ const setup = (props = defaultProps) => {
 };
 
 describe('Containers::PageEdit', () => {
-  it('should call clearErrors before mount', () => {
-    const { actions } = setup();
-    expect(actions.clearErrors).toHaveBeenCalled();
-  });
-
   it('should render correctly', () => {
     let { component } = setup(Object.assign(
       {}, defaultProps, { isFetching: true }

--- a/src/containers/views/tests/pagenew.spec.js
+++ b/src/containers/views/tests/pagenew.spec.js
@@ -42,11 +42,6 @@ function setup(props = defaultProps) {
 }
 
 describe('Containers::PageNew', () => {
-  it('should call clearErrors before mount', () => {
-    const { actions } = setup();
-    expect(actions.clearErrors).toHaveBeenCalled();
-  });
-
   it('should not render error messages initially', () => {
     const { errors } = setup();
     expect(errors.node).toNotExist();


### PR DESCRIPTION
Validation errors are being cleared every time components will mount via `clearErrors` action irrespective of their occurrence. Instead of doing this, clear them just before unmounting if there are any errors available in the state.