### PR TITLE
Only allow files that render to HTML to be written as a Page

### DIFF
--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -128,6 +128,7 @@ describe "pages" do
     request = {
       :front_matter => {},
       :raw_content  => "test",
+      :path         => "page-new.md",
     }
     put "/pages/page-new.md", request.to_json
 
@@ -143,6 +144,7 @@ describe "pages" do
     request = {
       :front_matter => { :foo => "bar" },
       :raw_content  => "test",
+      :path         => "page-new.md",
     }
     put "/pages/page-new.md", request.to_json
 
@@ -157,6 +159,7 @@ describe "pages" do
     request = {
       :front_matter => { :foo => "bar" },
       :raw_content  => "test",
+      :path         => "page-dir/page-new.md",
     }
     put "/pages/page-dir/page-new.md", request.to_json
 
@@ -167,12 +170,27 @@ describe "pages" do
     delete_file "page-dir/page-new.md"
   end
 
+  it "does not writes a non html page" do
+    expected_error = "Invalid file extension for pages"
+    request = {
+      :front_matter => { :foo => "bar" },
+      :raw_content  => "test",
+      :path         => "page-new.txt",
+    }
+    put "/pages/page-new.txt", request.to_json
+
+    expect(last_response).to be_unprocessable
+    expect(last_response_parsed["error_message"]).to eq(expected_error)
+    expect("page-new.md").to_not be_an_existing_file
+  end
+
   it "updates a page" do
     write_file "page-update.md"
 
     request = {
       :front_matter => { :foo => "bar2" },
       :raw_content  => "test",
+      :path         => "page-update.md",
     }
     put "/pages/page-update.md", request.to_json
     expect("page-update.md").to be_an_existing_file
@@ -189,6 +207,7 @@ describe "pages" do
     request = {
       :front_matter => { :foo => "bar2" },
       :raw_content  => "test",
+      :path         => "page-dir/page-update.md",
     }
     put "/pages/page-dir/page-update.md", request.to_json
     expect("page-dir/page-update.md").to be_an_existing_file

--- a/src/utils/api_errors.js
+++ b/src/utils/api_errors.js
@@ -1,0 +1,8 @@
+export class BadInputError extends Error {
+  constructor(message) {
+    super();
+    this.name = "BadInputError";
+    this.message = message || 'Bad input';
+    this.stack = (new Error()).stack;
+  }
+}

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -6,6 +6,7 @@ import {
   getUpdateErrorMessage,
   getDeleteMessage
 } from '../constants/lang';
+import { BadInputError } from './api_errors';
 
 /**
  * Fetch wrapper for GET request that dispatches actions according to the
@@ -50,18 +51,24 @@ export const put = (url, body, action_success, action_failure, dispatch) => {
     body
   })
   .then(res => res.json())
-  .then(data => dispatch({
-    type: action_success.type,
-    [action_success.name]: data
-  }))
+  .then(data => {
+    if (data.error_message){
+      throw new BadInputError(data.error_message);
+    }
+    dispatch({
+      type: action_success.type,
+      [action_success.name]: data
+    });
+  })
   .catch(error => {
     dispatch({
       type: action_failure.type,
       [action_failure.name]: error
     });
+    let error_message = error.name ==='BadInputError' ? error.message : getUpdateErrorMessage(action_success.name);
     dispatch(addNotification(
       getErrorMessage(),
-      getUpdateErrorMessage(action_success.name),
+      error_message,
       'error'
     ));
   });


### PR DESCRIPTION
Addresses #204 and #205. We are writing files that are considered Jekyll Pages but since #210 change, we should not allow the API to write anything that does not render to HTML