### PR TITLE
Support custom config files from CLI

### DIFF
--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -28,9 +28,17 @@ module JekyllAdmin
         configuration.read_config_file(configuration_path)
       end
 
+      def custom_configs
+        Jekyll::Commands::Serve.custom_configs
+      end
+
       # Returns the path to the *first* config file discovered
       def configuration_path
-        sanitized_path configuration.config_files(overrides).first
+        if custom_configs
+          sanitized_path custom_configs.first
+        else
+          sanitized_path configuration.config_files(overrides).first
+        end
       end
 
       # The user's uploaded configuration for updates

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -2,6 +2,21 @@ module Jekyll
   module Commands
     class Serve < Command
       class << self
+        def process(opts)
+          @overrides = opts["config"] if opts["config"]
+
+          opts = configuration_from_options(opts)
+          destination = opts["destination"]
+          setup(destination)
+
+          start_up_webrick(opts, destination)
+        end
+
+        def custom_configs
+          return nil unless @overrides
+          @overrides
+        end
+
         def start_up_webrick(opts, destination)
           server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)


### PR DESCRIPTION
Fixes #321 

When you provide an array of config files via the `--config` switch, we'll read and write to the first of such files.

- [x] add code
- [ ]  test code