### PR TITLE
Fix travis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
     - lib/jekyll-admin/public/**/*
     - src/**/*
     - node_modules/**/*
+    - Gemfile
+    - jekyll-admin.gemspec
 
 Metrics/BlockLength:
   Enabled: false

--- a/lib/jekyll-admin/server/collection.rb
+++ b/lib/jekyll-admin/server/collection.rb
@@ -2,7 +2,7 @@ module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/collections" do
       get do
-        json site.collections.map { |c| c[1].to_api }
+        json(site.collections.map { |c| c[1].to_api })
       end
 
       get "/:collection_id" do

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "redux-logger": "2.6.1",
     "redux-thunk": "2.1.0",
     "simplemde": "1.11.2",
-    "slug": "0.9.1",
+    "slug": "git+https://git@github.com/180-g/node-slug",
     "sortablejs": "1.4.2",
     "underscore": "1.8.3"
   },

--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -1,5 +1,5 @@
 describe JekyllAdmin::APIable do
-  [:page, :post].each do |type|
+  %i(page post).each do |type|
     context type do
       subject do
         documents = Jekyll.sites.first.send("#{type}s".to_sym)

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -48,8 +48,8 @@ describe "collections" do
     context "entries" do
       let(:entries) { last_response_parsed }
       let(:documents) do
-        entries.select do |entry|
-          !entry.key? "type"
+        entries.reject do |entry|
+          entry.key? "type"
         end
       end
       let(:first_document) { documents.first }

--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -16,8 +16,8 @@ describe "pages" do
   context "page index" do
     let(:entries) { last_response_parsed }
     let(:pages) do
-      entries.select do |entry|
-        !entry.key? "type"
+      entries.reject do |entry|
+        entry.key? "type"
       end
     end
     let(:first_page) { pages.first }

--- a/spec/jekyll-admin/server_spec.rb
+++ b/spec/jekyll-admin/server_spec.rb
@@ -9,8 +9,8 @@ describe JekyllAdmin::Server do
     get "/pages"
     expect(last_response).to be_ok
     entries = last_response_parsed
-    first_page = entries.select do |entry|
-      !entry.key? "type"
+    first_page = entries.reject do |entry|
+      entry.key? "type"
     end.first
     expect(first_page["path"]).to eq("page.md")
   end


### PR DESCRIPTION
Strangely unicode.org blacklisted our travis instance. Therefore it can't install `unicode` package we depend on. To workaround this, I'm replacing `unicode` package with the fork of it suggested [here](https://github.com/dodo/node-slug/issues/80) temporarily.

I also fixed a few rubocop errors since its rules has been updated recently.