### PR TITLE
Metadata StaticFilePicker

### DIFF
--- a/docs/_frontend/components.md
+++ b/docs/_frontend/components.md
@@ -68,6 +68,21 @@ Generic component for button element.
 }
 ```
 
+## Dropzone
+
+Component for uploading staticfiles.
+
+### PropTypes
+
+```javascript
+{
+  files: Array,
+  onDrop: Function,
+  onClickDelete: Function,
+  onClickItem: Function,
+}
+```
+
 ## FilePreview
 
 Component for previewing the uploaded file. It renders an image or a div according to

--- a/docs/_frontend/components.md
+++ b/docs/_frontend/components.md
@@ -144,7 +144,7 @@ Editable title component for edit views
 
 ## Metadata
 
-Set of components for handling documents' front matter(metafields).
+Set of components for handling documents' front matters (metafields).
 
 ### MetaField
 
@@ -152,8 +152,9 @@ Contains root attributes of the metadata.
 
 ### MetaSimple
 
-Leaf component that contains an simple input or date picker depending on the field's
-key. If the key is called `date`, it shows date picker for the value.
+Leaf component for metadata that contains a simple input, date picker or staticfile
+picker depending on the field's key.
+Special keys for additional functionalities are `date`, `file` and `image`.
 
 ### MetaArray
 
@@ -165,7 +166,7 @@ Convertible array item. Can be MetaArray, MetaObject or MetaSimple.
 
 ### MetaObject
 
-Contains sortable object items. Items are sorted visually, not stored in the state.
+Contains object items which allows entering key-value fields.
 
 ### MetaObjectItem
 
@@ -173,5 +174,5 @@ Convertible object item. Can be MetaArray, MetaObject or MetaSimple.
 
 ### MetaButtons
 
-Contains convert and delete buttons and sort handle. Dynamically shows the possible
+Contains `convert` and `delete` buttons and sort handle. Dynamically shows the possible
 conversion types.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-ace": "4.1.5",
     "react-dom": "15.4.1",
     "react-dropzone": "3.10.0",
+    "react-modal": "^1.7.3",
     "react-notification-system": "0.2.7",
     "react-redux": "5.0.1",
     "react-router": "3.0.0",

--- a/src/components/Dropzone.js
+++ b/src/components/Dropzone.js
@@ -1,0 +1,62 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import _ from 'underscore';
+import ReactDropzone from 'react-dropzone';
+import FilePreview from './FilePreview';
+
+export class Dropzone extends Component {
+
+  openDropzone() {
+    this.refs.dropzone.open();
+  }
+
+  render() {
+    const { files, onDrop, onClickDelete, onClickItem } = this.props;
+    let node;
+    if (files.length) {
+      node = (
+        <div className="preview-container">
+          {
+            _.map(files, (file, i) => {
+              return (
+                <FilePreview
+                  key={i}
+                  onClick={onClickItem}
+                  onClickDelete={onClickDelete}
+                  file={file} />
+              );
+            })
+          }
+        </div>
+      );
+    } else {
+      node = (
+        <div className="preview-info">
+          <i className="fa fa-upload" aria-hidden="true" />
+          <p>Drag and drop file(s) here to upload</p>
+        </div>
+      );
+    }
+    return (
+      <ReactDropzone
+        onDrop={onDrop}
+        ref="ReactDropzone"
+        className="dropzone"
+        activeClassName="dropzone-active"
+        multiple={true}
+        disableClick={true}>
+          {node}
+      </ReactDropzone>
+    );
+  }
+}
+
+Dropzone.propTypes = {
+  files: PropTypes.array.isRequired,
+  onDrop: PropTypes.func.isRequired,
+  onClickDelete: PropTypes.func.isRequired,
+  onClickItem: PropTypes.func,
+};
+
+export default Dropzone;

--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -14,20 +14,25 @@ export default class FilePreview extends Component {
   }
 
   render() {
-    const { file } = this.props;
+    const { onClick, file } = this.props;
     const extension = file.extname.substring(1);
-    const image = /png|jpg|gif|jpeg|svg/i.test(extension);
+    const image = /png|jpg|gif|jpeg|svg|ico/i.test(extension);
+    let node;
+    if (image) {
+      node = <img src={file.http_url} />;
+    } else {
+      node = <div><i className="fa fa-file-text-o" aria-hidden="true"/></div>;
+    }
+
+    let nodeLink;
+    if (onClick) {
+      nodeLink = <a onClick={onClick.bind(null, file.http_url)}>{node}</a>;
+    } else {
+      nodeLink = <a href={file.http_url} target="_blank">{node}</a>;
+    }
     return (
       <div className="file-preview">
-        <a href={file.http_url} target="_blank">
-        {
-          image && <img src={file.http_url} />
-        }
-        {
-          !image &&
-          <div><i className="fa fa-file-text-o" aria-hidden="true"/></div>
-        }
-        </a>
+        {nodeLink}
         <span className="filename">{file.path}</span>
         <button onClick={() => this.handleClickDelete(file.path)} className="delete" title="Delete file">x</button>
       </div>
@@ -37,5 +42,6 @@ export default class FilePreview extends Component {
 
 FilePreview.propTypes = {
   file: PropTypes.object.isRequired,
-  onClickDelete: PropTypes.func.isRequired
+  onClickDelete: PropTypes.func.isRequired,
+  onClick: PropTypes.func
 };

--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -3,15 +3,10 @@ import TextareaAutosize from 'react-textarea-autosize';
 import _ from 'underscore';
 import DateTimePicker from 'react-widgets/lib/DateTimePicker';
 import Modal from 'react-modal';
+import StaticFiles from '../../containers/views/StaticFiles';
 import moment from 'moment';
 import momentLocalizer from 'react-widgets/lib/localizers/moment';
 import 'react-widgets/dist/css/react-widgets.css';
-import Dropzone from '../Dropzone';
-import StaticFiles from '../../containers/views/StaticFiles';
-import { deleteStaticFile } from '../../actions/staticfiles';
-import {
-  staticfilesAPIUrl,
-} from '../../constants/api';
 
 momentLocalizer(moment);
 
@@ -25,7 +20,6 @@ export class MetaSimple extends Component {
     };
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
-    this.fetchStaticFiles = this.fetchStaticFiles.bind(this);
   }
 
   handleOpenModal () {
@@ -45,14 +39,6 @@ export class MetaSimple extends Component {
     const { nameAttr, fieldValue, updateFieldValue } = this.props;
     let formatted = moment(date).format("YYYY-MM-DD hh:mm:ss");
     updateFieldValue(nameAttr, formatted);
-  }
-
-  fetchStaticFiles() {
-    fetch(staticfilesAPIUrl())
-      .then(res => res.json())
-      .then(staticfiles => {
-        this.setState({staticfiles: staticfiles});
-      });
   }
 
   renderEditable() {
@@ -105,13 +91,11 @@ export class MetaSimple extends Component {
               overlay: {
                 backgroundColor: 'rgba(0,0,0,0.6)',
                 zIndex: 10,
-
               },
               content: {
                 margin: 50,
               }
-            }}
-           >
+            }} >
              <StaticFiles onClickStaticFile={(url) => this.onClickPickerItem(url)} />
           </Modal>
         </span>
@@ -139,7 +123,6 @@ export class MetaSimple extends Component {
       </div>
     );
   }
-
 }
 
 MetaSimple.propTypes = {

--- a/src/containers/MetaFields.js
+++ b/src/containers/MetaFields.js
@@ -55,9 +55,15 @@ export class MetaFields extends Component {
           <a onClick={() => addField('metadata')} className="tooltip">
             <i className="fa fa-plus-circle" /> New metadata field
             <span className="tooltip-text">
-              Metadata will be stored as the <b>YAML front matter</b> within the document.
+              Metadata will be stored as the <b>YAML front matter</b> within the document.ity.
             </span>
           </a>
+          <small className="tooltip pull-right">
+            <i className="fa fa-info-circle" />Special Keys
+            <span className="tooltip-text">
+              You can use special keys like <b>date</b>, <b>file</b>, <b>image</b> for user-friendly functionalities.
+            </span>
+          </small>
         </div>
       </div>
     );

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -1,12 +1,9 @@
 import React, { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import _ from 'underscore';
 import { ADMIN_PREFIX } from '../../constants';
-import Dropzone from 'react-dropzone';
+import Dropzone from '../../components/Dropzone';
 import Button from '../../components/Button';
-import FilePreview from '../../components/FilePreview';
 import InputSearch from '../../components/form/InputSearch';
 import { search } from '../../actions/utils';
 import { existingUploadedFilenames } from '../../utils/helpers.js';
@@ -36,42 +33,11 @@ export class StaticFiles extends Component {
   }
 
   openDropzone() {
-    this.refs.dropzone.open();
-  }
-
-  renderDropzone() {
-    const { files, deleteStaticFile } = this.props;
-    return (
-      <Dropzone
-        onDrop={(files) => this.onDrop(files)}
-        ref="dropzone"
-        className="dropzone"
-        activeClassName="dropzone-active"
-        multiple={true}
-        disableClick={true}>
-          {
-            files.length > 0 &&
-            <div className="preview-container">
-              {
-                _.map(files, (file, i) => {
-                  return <FilePreview onClickDelete={deleteStaticFile} key={i} file={file} />;
-                })
-              }
-            </div>
-          }
-          {
-            !files.length &&
-            <div className="preview-info">
-              <i className="fa fa-upload" aria-hidden="true" />
-              <p>Drag and drop file(s) here to upload</p>
-            </div>
-          }
-      </Dropzone>
-    );
+    this.refs.dropzone.refs.ReactDropzone.open();
   }
 
   render() {
-    const { files, isFetching, search } = this.props;
+    const { files, isFetching, deleteStaticFile, search, onClickStaticFile } = this.props;
 
     if (isFetching) {
       return null;
@@ -90,7 +56,12 @@ export class StaticFiles extends Component {
             <InputSearch searchBy="filename" search={search} />
           </div>
         </div>
-        {this.renderDropzone()}
+        <Dropzone
+          ref="dropzone"
+          files={files}
+          onClickItem={onClickStaticFile}
+          onClickDelete={deleteStaticFile}
+          onDrop={(files) => this.onDrop(files)} />
       </div>
     );
   }
@@ -102,6 +73,7 @@ StaticFiles.propTypes = {
   fetchStaticFiles: PropTypes.func.isRequired,
   uploadStaticFiles: PropTypes.func.isRequired,
   deleteStaticFile: PropTypes.func.isRequired,
+  onClickStaticFile: PropTypes.func,
   search: PropTypes.func.isRequired
 };
 

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -226,9 +226,6 @@
     i {
       padding-right: 8px;
     }
-    &:hover {
-      text-decoration: underline;
-    }
   }
   .sortable-chosen, .sortable-chosen.sortable-ghost {
     & div {
@@ -262,7 +259,7 @@
           background: #fff;
         }
         .rw-btn:first-child { border-right: 1px solid #ccc; }
-        .rw-btn:hover { background: #fc0; }
+        .rw-btn:hover { background: $orange; }
       }
     }
   }
@@ -284,5 +281,39 @@
   }
   .rw-list-option {
     padding: 8px 5px;
+  }
+
+  .imagepicker {
+    position: relative;
+    .images-wrapper {
+      position: absolute;
+      right: 0;
+      top: 0;
+      height: 100%;
+      padding: 2px;
+      button {
+        color: #333;
+        line-height: 2.286em;
+        height: 100%;
+        min-width: 37px;
+        display: inline-block;
+        margin: 0;
+        text-align: center;
+        vertical-align: middle;
+        background: white;
+        background-image: none;
+        border: none;
+        border-left: 1px solid #ccc;
+        padding: 0;
+        white-space: nowrap;
+        outline: none;
+        &:hover {
+          background: $orange;
+        }
+        i {
+          margin: 0;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
StaticfilePicker allows users to pick a static file url from a modal that lists all of the static files for their metafield values.

Also added a tooltip to inform users which special keys they can use for a metafield in order to use `DatePicker` and `StaticfilePicker`.

Here is the demo;

![staticfilepicker](https://cloud.githubusercontent.com/assets/7414026/24974700/c9edef02-1fcb-11e7-8e72-12c02c5c8061.gif)