### PR TITLE
Add support for standard save keyboard shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-ace": "4.1.5",
     "react-dom": "15.4.1",
     "react-dropzone": "3.10.0",
+    "react-hotkeys": "^0.9.0",
     "react-modal": "^1.7.3",
     "react-notification-system": "0.2.7",
     "react-redux": "5.0.1",

--- a/src/constants/keyboardShortcuts.js
+++ b/src/constants/keyboardShortcuts.js
@@ -1,0 +1,3 @@
+export default {
+  'save': 'mod+s',
+};

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,4 +1,7 @@
 import React, { Component, PropTypes } from 'react';
+import { HotKeys } from 'react-hotkeys';
+
+import keyboardShortcuts from '../constants/keyboardShortcuts';
 
 // Components
 import Sidebar from './Sidebar';
@@ -9,7 +12,9 @@ class App extends Component {
 
   render() {
     return (
-      <div className="wrapper">
+      <HotKeys
+        keyMap={keyboardShortcuts}
+        className="wrapper">
         <Sidebar />
         <div className="container">
           <Header />
@@ -18,7 +23,7 @@ class App extends Component {
           </div>
         </div>
         <Notifications />
-      </div>
+      </HotKeys>
     );
   }
 }

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -2,13 +2,20 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
+import { HotKeys } from 'react-hotkeys';
 import Editor from '../../components/Editor';
 import Button from '../../components/Button';
 import { putConfig, onEditorChange } from '../../actions/config';
 import { getLeaveMessage } from '../../constants/lang';
-import { toYAML } from '../../utils/helpers';
+import { toYAML, preventDefault } from '../../utils/helpers';
 
 export class Configuration extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.handleClickSave = this.handleClickSave.bind(this);
+  }
 
   componentDidMount() {
     const { router, route } = this.props;
@@ -21,7 +28,10 @@ export class Configuration extends Component {
     }
   }
 
-  handleClickSave() {
+  handleClickSave(e) {
+    // Prevent the default event from bubbling
+    preventDefault(e);
+
     const { editorChanged, putConfig } = this.props;
     if (editorChanged) {
       const value = this.refs.editor.getValue();
@@ -31,13 +41,18 @@ export class Configuration extends Component {
 
   render() {
     const { editorChanged, onEditorChange, config, updated } = this.props;
+
+    const keyboardHandlers = {
+      'save': this.handleClickSave,
+    };
+
     return (
-      <div>
+      <HotKeys handlers={keyboardHandlers}>
         <div className="content-header">
           <h1>Configuration</h1>
           <div className="page-buttons">
             <Button
-              onClick={() => this.handleClickSave()}
+              onClick={this.handleClickSave}
               type="save"
               active={editorChanged}
               triggered={updated} />
@@ -48,7 +63,7 @@ export class Configuration extends Component {
           onEditorChange={onEditorChange}
           content={toYAML(config)}
           ref="editor" />
-      </div>
+      </HotKeys>
     );
   }
 }

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -3,13 +3,14 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
+import { HotKeys } from 'react-hotkeys';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
 import Button from '../../components/Button';
 import { clearErrors } from '../../actions/utils';
-import { getFilenameFromPath } from '../../utils/helpers';
+import { getFilenameFromPath, preventDefault } from '../../utils/helpers';
 import {
   fetchDataFile, putDataFile, deleteDataFile, onDataFileChanged
 } from '../../actions/datafiles';
@@ -19,6 +20,12 @@ import {
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileEdit extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.handleClickSave = this.handleClickSave.bind(this);
+  }
 
   componentDidMount() {
     const { fetchDataFile, params, router, route } = this.props;
@@ -40,8 +47,12 @@ export class DataFileEdit extends Component {
     }
   }
 
-  handleClickSave() {
+  handleClickSave(e) {
     const { datafileChanged, putDataFile, params } = this.props;
+
+    // Prevent the default event from bubbling
+    preventDefault(e);
+
     if (datafileChanged) {
       const value = this.refs.editor.getValue();
       putDataFile(params.data_file, value);
@@ -74,8 +85,14 @@ export class DataFileEdit extends Component {
     const { path, raw_content } = datafile;
     const filename = getFilenameFromPath(path);
 
+    const keyboardHandlers = {
+      'save': this.handleClickSave,
+    };
+
     return (
-      <div className="single">
+      <HotKeys
+        handlers={keyboardHandlers}
+        className="single">
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
           <Breadcrumbs splat={filename} type="datafiles" />
@@ -92,7 +109,7 @@ export class DataFileEdit extends Component {
 
           <div className="content-side">
             <Button
-              onClick={() => this.handleClickSave()}
+              onClick={this.handleClickSave}
               type="save"
               active={datafileChanged}
               triggered={updated}
@@ -107,7 +124,7 @@ export class DataFileEdit extends Component {
               block />
           </div>
         </div>
-      </div>
+      </HotKeys>
     );
   }
 }

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
+import { HotKeys } from 'react-hotkeys';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
 import Breadcrumbs from '../../components/Breadcrumbs';
@@ -14,12 +15,19 @@ import Metadata from '../../containers/MetaFields';
 import { fetchDocument, deleteDocument, putDocument } from '../../actions/collections';
 import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
 import { clearErrors } from '../../actions/utils';
+import { preventDefault } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentEdit extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.handleClickSave = this.handleClickSave.bind(this);
+  }
 
   componentDidMount() {
     const { fetchDocument, params, router, route } = this.props;
@@ -58,8 +66,12 @@ export class DocumentEdit extends Component {
     }
   }
 
-  handleClickSave() {
+  handleClickSave(e) {
     const { putDocument, fieldChanged, params } = this.props;
+
+    // Prevent the default event from bubbling
+    preventDefault(e);
+
     if (fieldChanged) {
       const collection = params.collection_name;
       const [directory, ...rest] = params.splat;
@@ -101,8 +113,14 @@ export class DocumentEdit extends Component {
     } = currentDocument;
     const [directory, ...rest] = params.splat;
 
+    const keyboardHandlers = {
+      'save': this.handleClickSave,
+    };
+
     return (
-      <div className="single">
+      <HotKeys
+        handlers={keyboardHandlers}
+        className="single">
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
           <Breadcrumbs
@@ -116,7 +134,7 @@ export class DocumentEdit extends Component {
             <InputTitle onChange={updateTitle} title={title} ref="title" />
             <MarkdownEditor
               onChange={updateBody}
-              onSave={() => this.handleClickSave()}
+              onSave={this.handleClickSave}
               placeholder="Body"
               initialValue={raw_content}
               ref="editor" />
@@ -126,7 +144,7 @@ export class DocumentEdit extends Component {
 
           <div className="content-side">
             <Button
-              onClick={() => this.handleClickSave()}
+              onClick={this.handleClickSave}
               type="save"
               active={fieldChanged}
               triggered={updated}
@@ -150,7 +168,7 @@ export class DocumentEdit extends Component {
               block />
           </div>
         </div>
-      </div>
+      </HotKeys>
     );
   }
 }

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter, Link } from 'react-router';
 import _ from 'underscore';
+import { HotKeys } from 'react-hotkeys';
 import Button from '../../components/Button';
 import Splitter from '../../components/Splitter';
 import Errors from '../../components/Errors';
@@ -14,12 +15,19 @@ import Metadata from '../MetaFields';
 import { fetchPage, deletePage, putPage } from '../../actions/pages';
 import { updateTitle, updateBody, updatePath } from '../../actions/metadata';
 import { clearErrors } from '../../actions/utils';
+import { preventDefault } from '../../utils/helpers';
 import {
   getLeaveMessage, getDeleteMessage, getNotFoundMessage
 } from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class PageEdit extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.handleClickSave = this.handleClickSave.bind(this);
+  }
 
   componentDidMount() {
     const { fetchPage, params, router, route } = this.props;
@@ -55,8 +63,12 @@ export class PageEdit extends Component {
     }
   }
 
-  handleClickSave() {
+  handleClickSave(e) {
     const { putPage, fieldChanged, params } = this.props;
+
+    // Prevent the default event from bubbling
+    preventDefault(e);
+
     if (fieldChanged) {
       const [directory, ...rest] = params.splat;
       const filename = rest.join('.');
@@ -87,11 +99,17 @@ export class PageEdit extends Component {
       return <h1>{`Could not find the page.`}</h1>;
     }
 
+    const keyboardHandlers = {
+      'save': this.handleClickSave,
+    };
+
     const { name, raw_content, http_url, path, front_matter } = page;
     const [directory, ...rest] = params.splat;
     const title = front_matter && front_matter.title ? front_matter.title : '';
     return (
-      <div className="single">
+      <HotKeys
+        handlers={keyboardHandlers}
+        className="single">
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
           <Breadcrumbs splat={directory || ''} type="pages" />
@@ -103,7 +121,7 @@ export class PageEdit extends Component {
             <InputTitle onChange={updateTitle} title={title} ref="title" />
             <MarkdownEditor
               onChange={updateBody}
-              onSave={() => this.handleClickSave()}
+              onSave={this.handleClickSave}
               placeholder="Body"
               initialValue={raw_content}
               ref="editor" />
@@ -113,7 +131,7 @@ export class PageEdit extends Component {
 
           <div className="content-side">
             <Button
-              onClick={() => this.handleClickSave()}
+              onClick={this.handleClickSave}
               type="save"
               active={fieldChanged}
               triggered={updated}
@@ -134,7 +152,7 @@ export class PageEdit extends Component {
               block />
           </div>
         </div>
-      </div>
+      </HotKeys>
     );
   }
 

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -102,6 +102,10 @@
   }
 
   .single {
+    &:focus {
+      outline: none;
+    }
+
     .breadcrumbs {
       width: 100%;
       input {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -53,6 +53,10 @@ b {
 
 .wrapper {
   height: 100%;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 .container {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -74,3 +74,14 @@ export const existingUploadedFilenames = (uploadedFiles, currentFiles) => {
     .map(file => file.name)
     .value();
 };
+
+/**
+ * Given an Event object, prevents the default event
+ * from bubbling, if possible.
+ * @param {Event} event
+ */
+export const preventDefault = (event) => {
+  if (event && event.preventDefault) {
+    event.preventDefault();
+  }
+};


### PR DESCRIPTION
## Overview

Adds support for the standard "Save" keyboard shortcut: Command+s on OSX,
or Ctrl+s on Linux and Windows.

This change introduces a new dependency, react-hotkeys, which will make
it trivial to add additional keyboard shortcuts in the future.

Closes #304

cc: @JohannesMP @mertkahyaoglu 