### PR TITLE
Support editing raw config file via admin interface

### DIFF
--- a/docs/_frontend/actions.md
+++ b/docs/_frontend/actions.md
@@ -7,11 +7,15 @@ description: Actions are payloads of information that send data from the applica
 
 ### > `fetchConfig`
 
-Async action for fetching Jekyll project configuration (`_config.yml`)
+Async action for fetching an object comprised of Jekyll project configuration (from `_config.yml` by default)
 
 ### > `putConfig(config)`
 
-Async action for updating Jekyll project configuration
+Async action for updating Jekyll project configuration, after ensuring the content is not empty.
+
+### > `validateConfig(config)`
+
+Action for checking whether the YAML editor has content.
 
 ### > `onEditorChange`
 

--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -25,7 +25,8 @@ Container for displaying header which includes title and homepage link.
 ```javascript
 {
   config: Object,
-  fetchConfig: Function
+  fetchConfig: Function,
+  updated: Boolean \\ optional
 }
 ```
 
@@ -82,7 +83,11 @@ The button is activated when the editor changes.
   putConfig: Function,
   error: String,
   updated: Boolean,
-  editorChanged: Boolean
+  editorChanged: Boolean,
+  errors: Array,
+  clearErrors: Function,
+  router: Object,
+  route: Object
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,11 +73,17 @@ A standard JSON object of a directory looks like this:
 
 #### Data files and the config file
 
-Data files and the config file are direct JSON representations of the underlying YAML File.
+Data files are a direct JSON representations of the underlying YAML File.
+A JSON object from the config file has the data segregated into two representations:
+
+* `content` - the parsed configuration data as read by Jekyll.
+* `raw_content` - the raw data as it sits on the disk.
 
 #### Static files
 
 Static files are non-Jekyll files and may be binary or text.
+
+---
 
 ### Collections
 
@@ -143,13 +149,13 @@ Delete the requested page from disk.
 
 #### `GET /configuration`
 
-Returns the parsed site configuration.
+Returns a hash object comprised of the parsed configuration from the file and the raw unparsed content of the file.
 
 #### `PUT /configuration`
 
-Create or update the site's `_config.yml` file with the requested contents.
+Create or update the site's `_config.yml` file with the requested raw file content string.
 
-File will be written to disk in YAML. It will not necessarily preserve whitespace or inline comments.
+File will be written to disk verbatim, preserving whitespace and inline comments.
 
 ### Static files
 

--- a/spec/jekyll-admin/server/configuration_spec.rb
+++ b/spec/jekyll-admin/server/configuration_spec.rb
@@ -8,7 +8,7 @@ describe "configuration" do
   it "returns the configuration" do
     get "/configuration"
     expect(last_response).to be_ok
-    expect(last_response_parsed["foo"]).to eql("bar")
+    expect(last_response_parsed["content"]["foo"]).to eql("bar")
     expect(last_response_parsed.key?("source")).to eql(false)
   end
 

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -4,6 +4,7 @@ import { getContentRequiredMessage } from '../constants/lang';
 import { addNotification } from './notifications';
 import { get, put } from '../utils/fetch';
 import { validator } from '../utils/validation';
+import { validationError } from './utils';
 
 export function fetchConfig() {
   return dispatch => {

--- a/src/actions/config.js
+++ b/src/actions/config.js
@@ -1,9 +1,9 @@
 import * as ActionTypes from '../constants/actionTypes';
 import { getConfigurationUrl, putConfigurationUrl } from '../constants/api';
-import { getParserErrorMessage } from '../constants/lang';
+import { getContentRequiredMessage } from '../constants/lang';
 import { addNotification } from './notifications';
 import { get, put } from '../utils/fetch';
-import { toJSON } from '../utils/helpers';
+import { validator } from '../utils/validation';
 
 export function fetchConfig() {
   return dispatch => {
@@ -18,21 +18,31 @@ export function fetchConfig() {
 }
 
 export function putConfig(config) {
-  return (dispatch) => {
-    let json;
-    try {
-      json = toJSON(config);
-    } catch (e) {
-      return dispatch(addNotification(getParserErrorMessage(), e.message, 'error'));
+  return (dispatch, getState) => {
+    const errors = validateConfig(config);
+    if (errors.length) {
+      return dispatch(validationError(errors));
     }
+    // clear errors
+    dispatch({type: ActionTypes.CLEAR_ERRORS});
     return put(
       putConfigurationUrl(),
-      JSON.stringify(json),
+      JSON.stringify({ raw_content: config }),
       { type: ActionTypes.PUT_CONFIG_SUCCESS, name: "config"},
       { type: ActionTypes.PUT_CONFIG_FAILURE, name: "error"},
       dispatch
     );
   };
+}
+
+function validateConfig(config) {
+  return validator(
+    { config },
+    { 'config': 'required' },
+    {
+      'config.required': getContentRequiredMessage()
+    }
+  );
 }
 
 export function onEditorChange() {

--- a/src/actions/tests/config.spec.js
+++ b/src/actions/tests/config.spec.js
@@ -36,13 +36,13 @@ describe('Actions::Config', () => {
 
   it('updates the configuration', () => {
     nock(API)
-      .put('/configuration', config)
+      .put('/configuration')
       .reply(200, config);
 
-    const expectedAction = [{
-      type: types.PUT_CONFIG_SUCCESS,
-      config
-    }];
+    const expectedAction = [
+      { type: types.CLEAR_ERRORS },
+      { type: types.PUT_CONFIG_SUCCESS, config }
+    ];
 
     const store = mockStore({ config: {} });
     return store.dispatch(actions.putConfig(config_yaml))
@@ -56,15 +56,16 @@ describe('Actions::Config', () => {
       .put('/configuration', config)
       .replyWithError('something awful happened');
 
-    const expectedAction = {
-      type: types.PUT_CONFIG_FAILURE
-    };
+    const expectedAction = [
+      { type: types.CLEAR_ERRORS },
+      { type: types.PUT_CONFIG_FAILURE }
+    ];
 
     const store = mockStore({ config: {} });
 
     return store.dispatch(actions.putConfig(config_yaml))
       .then(() => {
-        expect(store.getActions()[0].type).toEqual(expectedAction.type);
+        expect(store.getActions()[1].type).toEqual(expectedAction[1].type);
       });
   });
 });

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -12,14 +12,25 @@ export class Header extends Component {
     fetchConfig();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.updated !== nextProps.updated) {
+      const { fetchConfig } = this.props;
+      fetchConfig();
+    }
+  }
+
   render() {
     const { config } = this.props;
+    const configuration = config.content;
     return (
       <div className="header">
         <h3 className="title">
           <Link target="_blank" to={`/`}>
             <i className="fa fa-home" />
-            <span>{config.title || 'You have no title!'}</span>
+            {
+              configuration &&
+                <span>{configuration.title || 'You have no title!'}</span>
+            }
           </Link>
         </h3>
         <span className="version">{VERSION}</span>
@@ -30,11 +41,13 @@ export class Header extends Component {
 
 Header.propTypes = {
   fetchConfig: PropTypes.func.isRequired,
-  config: PropTypes.object.isRequired
+  config: PropTypes.object.isRequired,
+  updated: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({
   config: state.config.config,
+  updated: state.config.updated,
   isFetching: state.config.isFetching
 });
 

--- a/src/containers/tests/fixtures/index.js
+++ b/src/containers/tests/fixtures/index.js
@@ -1,9 +1,11 @@
 export const config = {
-  title: "Your awesome title",
-  email: "your-email@domain.com",
-  description: "Write an awesome description for your new site here.",
-  baseurl: "",
-  url: "http://yourdomain.com"
+  content: {
+    title: "Your awesome title",
+    email: "your-email@domain.com",
+    baseurl: "",
+    url: "http://yourdomain.com"
+  },
+  raw_content: "title: Your awesome title\nemail: your-email@domain.com\nbaseurl:\nurl: http://yourdomain.com"
 };
 
 export const collections = [

--- a/src/containers/tests/header.spec.js
+++ b/src/containers/tests/header.spec.js
@@ -24,8 +24,9 @@ function setup() {
 describe('Containers::Header', () => {
   it('should render correctly', () => {
     const { title, component } = setup();
+    const { content } = config;
     const actual = title.text();
-    const expected = config.title;
+    const expected = content.title;
     expect(actual).toEqual(expected);
   });
 

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -2,9 +2,11 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
+import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
 import Button from '../../components/Button';
 import { putConfig, onEditorChange } from '../../actions/config';
+import { clearErrors } from '../../actions/utils';
 import { getLeaveMessage } from '../../constants/lang';
 import { toYAML } from '../../utils/helpers';
 
@@ -13,6 +15,14 @@ export class Configuration extends Component {
   componentDidMount() {
     const { router, route } = this.props;
     router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
+  }
+
+  componentWillUnmount() {
+    const { clearErrors, errors } = this.props;
+    // clear errors if any
+    if (errors.length) {
+      clearErrors();
+    }
   }
 
   routerWillLeave(nextLocation) {
@@ -30,10 +40,11 @@ export class Configuration extends Component {
   }
 
   render() {
-    const { editorChanged, onEditorChange, config, updated } = this.props;
+    const { editorChanged, onEditorChange, config, updated, errors } = this.props;
     const { raw_content } = config;
     return (
-      <div>
+      <div className="single">
+        {errors && errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
           <h1>Configuration</h1>
           <div className="page-buttons">
@@ -63,6 +74,8 @@ Configuration.propTypes = {
   putConfig: PropTypes.func.isRequired,
   updated: PropTypes.bool.isRequired,
   editorChanged: PropTypes.bool.isRequired,
+  errors: PropTypes.array.isRequired,
+  clearErrors: PropTypes.func.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired
 };
@@ -70,12 +83,14 @@ Configuration.propTypes = {
 const mapStateToProps = (state) => ({
   config: state.config.config,
   updated: state.config.updated,
-  editorChanged: state.config.editorChanged
+  editorChanged: state.config.editorChanged,
+  errors: state.utils.errors
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   putConfig,
-  onEditorChange
+  onEditorChange,
+  clearErrors
 }, dispatch);
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Configuration));

--- a/src/containers/views/Configuration.js
+++ b/src/containers/views/Configuration.js
@@ -31,6 +31,7 @@ export class Configuration extends Component {
 
   render() {
     const { editorChanged, onEditorChange, config, updated } = this.props;
+    const { raw_content } = config;
     return (
       <div>
         <div className="content-header">
@@ -43,11 +44,14 @@ export class Configuration extends Component {
               triggered={updated} />
           </div>
         </div>
-        <Editor
-          editorChanged={editorChanged}
-          onEditorChange={onEditorChange}
-          content={toYAML(config)}
-          ref="editor" />
+        {
+          raw_content &&
+            <Editor
+              editorChanged={editorChanged}
+              onEditorChange={onEditorChange}
+              content={raw_content}
+              ref="editor" />
+        }
       </div>
     );
   }

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -49,4 +49,16 @@ describe('Containers::Configuration', () => {
     expect(saveButton.prop('triggered')).toBe(true);
     expect(saveButton.prop('active')).toBe(true);
   });
+
+  it('should not render error messages with initial props', () => {
+    const { errors } = setup();
+    expect(errors.node).toNotExist();
+  });
+
+  it('should render error messages when necessary', () => {
+    const { errors } = setup(Object.assign({}, defaultProps, {
+      errors: ['The content is required.']
+    }));
+    expect(errors.node).toExist();
+  });
 });

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import expect from 'expect';
+import Errors from '../../../components/Errors';
 import Editor from '../../../components/Editor';
 import Button from '../../../components/Button';
 import { Configuration } from '../Configuration';
@@ -10,9 +11,11 @@ import { config } from './fixtures';
 const defaultProps = {
   config,
   editorChanged: false,
-  updated: false,
+  errors: [],
   router: {},
   route: {},
+  updated: false,
+  clearErrors: expect.createSpy(),
   onEditorChange: expect.createSpy(),
   putConfig: expect.createSpy()
 };
@@ -22,6 +25,7 @@ const setup = (props = defaultProps) => {
   return {
     component,
     editor: component.find(Editor),
+    errors: component.find(Errors),
     saveButton: component.find(Button)
   };
 };
@@ -29,7 +33,8 @@ const setup = (props = defaultProps) => {
 describe('Containers::Configuration', () => {
   it('should render correctly with initial props', () => {
     const { component, editor, saveButton } = setup();
-    expect(editor.prop('content')).toEqual(toYAML(config));
+    const { raw_content } = config;
+    expect(editor.prop('content')).toEqual(raw_content);
     expect(saveButton.prop('active')).toBe(false);
     expect(saveButton.prop('triggered')).toBe(false);
   });

--- a/src/containers/views/tests/fixtures/index.js
+++ b/src/containers/views/tests/fixtures/index.js
@@ -1,8 +1,11 @@
 export const config = {
-  title: "Your awesome title",
-  email: "your-email@domain.com",
-  description: "Write an awesome description for your new site here.\n",
-  url: "http://yourdomain.com"
+  content: {
+    title: "Your awesome title",
+    email: "your-email@domain.com",
+    baseurl: "",
+    url: "http://yourdomain.com"
+  },
+  raw_content: "title: Your awesome title\nemail: your-email@domain.com\nbaseurl:\nurl: http://yourdomain.com"
 };
 
 export const doc = {


### PR DESCRIPTION
Fixes #295 

The interface now loads **the raw content** from the first config file found and writes to the same file.
Additional changes made to have the code for `Configuration` resemble that for `DataFiles`

- [x] Update API
- [x] Update frontend
- [x] Update docs

Thanks :smiley: