### PR TITLE
Ignore `npm-debug` logs with additional extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ _site/
 /spec/reports/
 /tmp/
 /spec/fixtures/site/_site
-npm-debug.log
+npm-debug.log*
 /spec/fixtures/site/Gemfile.lock
 node_modules
 /lib/jekyll-admin/public


### PR DESCRIPTION
e.g. ignore `npm-debug.log.653637`