### PR TITLE
Reset state on failed fetchs

### DIFF
--- a/src/reducers/collections.js
+++ b/src/reducers/collections.js
@@ -38,9 +38,18 @@ export default function collections(state = {
         isFetching: false
       });
     case FETCH_COLLECTIONS_FAILURE:
+      return Object.assign({}, state, {
+        collections: [],
+        isFetching: false
+      });
     case FETCH_COLLECTION_FAILURE:
+      return Object.assign({}, state, {
+        entries: [],
+        isFetching: false
+      });
     case FETCH_DOCUMENT_FAILURE:
       return Object.assign({}, state, {
+        currentDocument: {},
         isFetching: false
       });
     case PUT_DOCUMENT_SUCCESS:

--- a/src/reducers/pages.js
+++ b/src/reducers/pages.js
@@ -27,7 +27,7 @@ export default function pages(state = {
     case FETCH_PAGES_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
-        page: {}
+        pages: []
       });
     case FETCH_PAGE_SUCCESS:
       return Object.assign({}, state, {

--- a/src/reducers/tests/collections.spec.js
+++ b/src/reducers/tests/collections.spec.js
@@ -37,7 +37,8 @@ describe('Reducers::Collections', () => {
         type: types.FETCH_COLLECTIONS_FAILURE
       })
     ).toEqual({
-      isFetching: false
+      isFetching: false,
+      collections: []
     });
   });
 
@@ -63,6 +64,7 @@ describe('Reducers::Collections', () => {
         type: types.FETCH_COLLECTION_FAILURE
       })
     ).toEqual({
+      entries: [],
       isFetching: false
     });
   });

--- a/src/reducers/tests/pages.spec.js
+++ b/src/reducers/tests/pages.spec.js
@@ -37,7 +37,7 @@ describe('Reducers::Pages', () => {
         type: types.FETCH_PAGES_FAILURE
       })
     ).toEqual({
-      page: {},
+      pages: [],
       isFetching: false
     });
   });


### PR DESCRIPTION
There might be cases when fetching from the api results in 404. We should always reset the front-end state in these cases to prevent showing already fetched data (cached in React store).

For example you visit `puppies` collection and move onto `posts` but somehow posts data couldn't be fetched. You don't want to see `puppies` entries there.