### PR TITLE
Webpack Bundle Analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "sass-loader": "4.1.0",
     "style-loader": "0.13.1",
     "webpack": "2.2.1",
+    "webpack-bundle-analyzer": "^2.4.0",
     "webpack-dev-middleware": "1.9.0",
     "webpack-hot-middleware": "2.13.2"
   }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,6 +1,7 @@
 import webpack from 'webpack';
 import path from 'path';
 import { ADMIN_PREFIX } from './src/constants';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 const GLOBALS = {
   'process.env.NODE_ENV': JSON.stringify('development'),
@@ -34,6 +35,9 @@ export default {
         },
         context: '/'
       }
+    }),
+    new BundleAnalyzerPlugin({
+      openAnalyzer: false,
     })
   ],
   module: {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,7 +37,9 @@ export default {
       }
     }),
     new BundleAnalyzerPlugin({
-      openAnalyzer: false,
+      analyzerMode: 'static',
+      logLevel: 'silent',
+      openAnalyzer: false
     })
   ],
   module: {


### PR DESCRIPTION
Why;

```
1. Realize what's really inside the front-end bundle
2. Find out what modules make up the most of it's size
3. Find modules that got there by mistake
4. Optimize it
```

How;
Open `report.html` in public folder generated via webpack.

![screen shot 2017-04-29 at 15 41 14](https://cloud.githubusercontent.com/assets/7414026/25555584/f0627fc0-2cf2-11e7-82d6-a05208f7755f.png)

**Note:** Looking at this, I realised that we should get rid of `unicode` module and use a custom slugify function instead.