### PR TITLE
Replace slug module with a custom function to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "redux-logger": "2.6.1",
     "redux-thunk": "2.1.0",
     "simplemde": "1.11.2",
-    "slug": "git+https://git@github.com/180-g/node-slug",
     "sortablejs": "1.4.2",
     "underscore": "1.8.3"
   },

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,6 +1,5 @@
 import yaml from 'js-yaml';
 import _ from 'underscore';
-import slug from 'slug';
 
 /**
  * Converts the object into YAML string.
@@ -43,10 +42,22 @@ export const toTitleCase = (string) => {
  * @param {String} string
  * @return {String} string
  */
-export const slugify = (string) => {
-  if (!string) return '';
-  return slug(string,{lower:true}).replace(/^-+|-+$/g, '');
-};
+ export const slugify = (string) => {
+   if (!string) return '';
+   const a = 'àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;';
+   const b = 'aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------';
+   const p = new RegExp(a.split('').join('|'), 'g');
+
+   return string.toString().toLowerCase()
+     .replace(/\s+/g, '-')           // Replace spaces with -
+     .replace(p, c =>
+         b.charAt(a.indexOf(c)))     // Replace special chars
+     .replace(/&/g, '-')             // Replace & with 'and'
+     .replace(/[^\w\-]+/g, '')       // Remove all non-word chars
+     .replace(/\-\-+/g, '-')         // Replace multiple - with single -
+     .replace(/^-+/, '')             // Trim - from start of text
+     .replace(/-+$/, '');             // Trim - from end of text
+ };
 
 /**
  * Returns filename from the given path

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -44,8 +44,8 @@ export const toTitleCase = (string) => {
  */
  export const slugify = (string) => {
    if (!string) return '';
-   const a = 'àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;';
-   const b = 'aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------';
+   const a = 'àáäâèéëêìíïîıòóöôùúüûñçşßÿœæŕśńṕẃǵğǹḿǘẍźḧ·/_,:;';
+   const b = 'aaaaeeeeiiiiioooouuuuncssyoarsnpwggnmuxzh------';
    const p = new RegExp(a.split('').join('|'), 'g');
 
    return string.toString().toLowerCase()


### PR DESCRIPTION
Removing `slug` module will reduce the production bundle size from `4MB` to `2.4MB`.