### PR TITLE
Support hiding sidebar links

### DIFF
--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -5,7 +5,15 @@ description: Container components which connect the presentational components to
 
 ## Sidebar
 
-Container for listing all of routes' links.
+Container for listing all of routes' links. The links can be hidden from `Sidebar` by adding
+an option to `_config.yml` like the following;
+
+```yaml
+jekyll_admin:
+  hidden_links:
+    - posts
+    - pages
+```
 
 ### PropTypes
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,6 +1,9 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { HotKeys } from 'react-hotkeys';
 
+import { fetchConfig } from '../actions/config';
 import keyboardShortcuts from '../constants/keyboardShortcuts';
 
 // Components
@@ -10,14 +13,32 @@ import Notifications from './Notifications';
 
 class App extends Component {
 
+  componentDidMount() {
+    const { fetchConfig } = this.props;
+    fetchConfig();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.updated !== nextProps.updated) {
+      const { fetchConfig } = this.props;
+      fetchConfig();
+    }
+  }
+
   render() {
+    const { config, isFetching } = this.props;
+
+    if (isFetching) {
+      return null;
+    }
+
     return (
       <HotKeys
         keyMap={keyboardShortcuts}
         className="wrapper">
-        <Sidebar />
+        <Sidebar config={config} />
         <div className="container">
-          <Header />
+          <Header config={config} />
           <div className="content">
             {this.props.children}
           </div>
@@ -29,7 +50,21 @@ class App extends Component {
 }
 
 App.propTypes = {
-  children: PropTypes.element
+  children: PropTypes.element,
+  fetchConfig: PropTypes.func.isRequired,
+  config: PropTypes.object.isRequired,
+  isFetching: PropTypes.bool.isRequired,
+  updated: PropTypes.bool
 };
 
-export default App;
+const mapStateToProps = (state) => ({
+  config: state.config.config,
+  updated: state.config.updated,
+  isFetching: state.config.isFetching,
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  fetchConfig
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -2,22 +2,9 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
-import { fetchConfig } from '../actions/config';
 import { VERSION } from '../constants';
 
 export class Header extends Component {
-
-  componentDidMount() {
-    const { fetchConfig } = this.props;
-    fetchConfig();
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.updated !== nextProps.updated) {
-      const { fetchConfig } = this.props;
-      fetchConfig();
-    }
-  }
 
   render() {
     const { config } = this.props;
@@ -25,11 +12,10 @@ export class Header extends Component {
     return (
       <div className="header">
         <h3 className="title">
-          <Link target="_blank" to={`/`}>
+          <Link target="_blank" to="/">
             <i className="fa fa-home" />
             {
-              configuration &&
-                <span>{configuration.title || 'You have no title!'}</span>
+              configuration && <span>{configuration.title || 'You have no title!'}</span>
             }
           </Link>
         </h3>
@@ -40,19 +26,7 @@ export class Header extends Component {
 }
 
 Header.propTypes = {
-  fetchConfig: PropTypes.func.isRequired,
   config: PropTypes.object.isRequired,
-  updated: PropTypes.bool
 };
 
-const mapStateToProps = (state) => ({
-  config: state.config.config,
-  updated: state.config.updated,
-  isFetching: state.config.isFetching
-});
-
-const mapDispatchToProps = (dispatch) => bindActionCreators({
-  fetchConfig
-}, dispatch);
-
-export default connect(mapStateToProps, mapDispatchToProps)(Header);
+export default Header;

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -6,7 +6,7 @@ import { ADMIN_PREFIX } from '../constants';
 import Splitter from '../components/Splitter';
 import { fetchCollections } from '../actions/collections';
 import { capitalize } from '../utils/helpers';
-import { sidebar } from '../constants/lang';
+import { sidebar as SidebarTranslations } from '../constants/lang';
 import _ from 'underscore';
 
 export class Sidebar extends Component {
@@ -16,56 +16,80 @@ export class Sidebar extends Component {
     fetchCollections();
   }
 
-  renderCollections() {
+  renderCollections(hiddens = []) {
     const { collections } = this.props;
 
     if (!collections.length) {
       return null;
     }
 
-    return _.map(collections, (col, i) =>
-      <li key={i}>
-        <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/${col.label}`}>
-          <i className="fa fa-book" />{capitalize(col.label)}
-        </Link>
-      </li>
-    );
+    return _.map(collections, (col, i) => {
+      if (_.indexOf(hiddens, col.label) == -1) {
+        return (
+          <li key={i}>
+            <Link activeClassName="active" to={`${ADMIN_PREFIX}/collections/${col.label}`}>
+              <i className="fa fa-book" />{capitalize(col.label)}
+            </Link>
+          </li>
+        );
+      }
+    });
   }
 
   render() {
+    const { config } = this.props;
+
+    const defaults = {
+      pages: {
+        icon: 'file-text',
+        link: 'pages',
+        translation: 'pages'
+      },
+      datafiles: {
+        icon: 'database',
+        link: 'datafiles',
+        translation: 'datafiles',
+        splitterBefore: true
+      },
+      staticfiles: {
+        icon: 'file',
+        link: 'staticfiles',
+        translation: 'staticfiles'
+      },
+      configuration: {
+        icon: 'cog',
+        link: 'configuration',
+        translation: 'configuration',
+        splitterBefore: true
+      },
+    };
+
+    const defaultLinks = _.keys(defaults);
+    const hiddenLinks = config.content.hidden_links ? config.content.hidden_links : [];
+    const visibleLinks = _.difference(defaultLinks, hiddenLinks);
+
+    const links = [];
+    _.each(visibleLinks, (link, index, list) => {
+      const current = defaults[link];
+      if (current.splitterBefore) {
+        links.push(<Splitter />);
+      }
+      links.push(
+        <li key={index}>
+          <Link activeClassName="active" to={`${ADMIN_PREFIX}/${current.link}`}>
+            <i className={`fa fa-${current.icon}`} />
+            {SidebarTranslations[current.translation]}
+          </Link>
+        </li>
+      );
+    });
+
     return (
       <div className="sidebar">
         <Link className="logo" to={`${ADMIN_PREFIX}/pages`} />
         <ul className="routes">
-          <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/pages`}>
-              <i className="fa fa-file-text" />
-              {sidebar.pages}
-            </Link>
-          </li>
-
-          {this.renderCollections()}
-
-          <Splitter />
-          <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/datafiles`}>
-              <i className="fa fa-database" />
-              {sidebar.datafiles}
-            </Link>
-          </li>
-          <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/staticfiles`}>
-              <i className="fa fa-file" />
-              {sidebar.staticfiles}
-            </Link>
-          </li>
-          <Splitter />
-          <li>
-            <Link activeClassName="active" to={`${ADMIN_PREFIX}/configuration`}>
-              <i className="fa fa-cog" />
-              {sidebar.configuration}
-            </Link>
-          </li>
+          {this.renderCollections(hiddenLinks)}
+          {links}
         </ul>
       </div>
     );
@@ -74,7 +98,8 @@ export class Sidebar extends Component {
 
 Sidebar.propTypes = {
   collections: PropTypes.array.isRequired,
-  fetchCollections: PropTypes.func.isRequired
+  fetchCollections: PropTypes.func.isRequired,
+  config: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -38,6 +38,7 @@ export class Sidebar extends Component {
 
   render() {
     const { config } = this.props;
+    const content = config.content;
 
     const defaults = {
       pages: {
@@ -65,14 +66,20 @@ export class Sidebar extends Component {
     };
 
     const defaultLinks = _.keys(defaults);
-    const hiddenLinks = config.content.hidden_links ? config.content.hidden_links : [];
+    let hiddenLinks;
+    try {
+      hiddenLinks = config.content.jekyll_admin.hidden_links;
+    } catch (e) {
+      hiddenLinks = [];
+    }
+
     const visibleLinks = _.difference(defaultLinks, hiddenLinks);
 
     const links = [];
     _.each(visibleLinks, (link, index, list) => {
       const current = defaults[link];
       if (current.splitterBefore) {
-        links.push(<Splitter />);
+        links.push(<Splitter key={'splitter'+index} />);
       }
       links.push(
         <li key={index}>

--- a/src/containers/tests/fixtures/index.js
+++ b/src/containers/tests/fixtures/index.js
@@ -9,8 +9,14 @@ export const config = {
 };
 
 export const collections = [
-  {title: "Posts", path: "/posts" },
-  {title: "Movies", path: "/movies"}
+  {
+    label: "posts",
+    path: "/posts"
+  },
+  {
+    label: "movies",
+    path: "/movies"
+  }
 ];
 
 export const content = {

--- a/src/containers/tests/header.spec.js
+++ b/src/containers/tests/header.spec.js
@@ -5,17 +5,13 @@ import { Header } from '../Header';
 import { config } from './fixtures';
 
 function setup() {
-  const actions = {
-    fetchConfig: jest.fn()
-  };
 
   const component = mount(
-    <Header config={config} {...actions} />
+    <Header config={config} />
   );
 
   return {
     component: component,
-    actions: actions,
     title: component.find('h3 span')
   };
 }
@@ -27,10 +23,5 @@ describe('Containers::Header', () => {
     const actual = title.text();
     const expected = content.title;
     expect(actual).toEqual(expected);
-  });
-
-  it('should call fetchConfig action after mounted', () => {
-    const { actions } = setup();
-    expect(actions.fetchConfig).toHaveBeenCalled();
   });
 });

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'underscore';
 import { mount } from 'enzyme';
 import { Link } from 'react-router';
 import { Sidebar } from '../Sidebar';
@@ -6,9 +7,11 @@ import { Sidebar } from '../Sidebar';
 import { collections, config } from './fixtures';
 
 const defaultProps = {
-  config: config,
-  collections: collections,
+  config,
+  collections,
 };
+
+const nonCollectionLinks = ['pages', 'datafiles', 'staticfiles', 'configuration'];
 
 function setup(props=defaultProps) {
   const actions = {
@@ -28,8 +31,30 @@ describe('Containers::Sidebar', () => {
   it('should render correctly', () => {
     const { links, component } = setup();
     const actual = links.length;
-    const expected = 4 + component.prop('collections').length;
+    const expected = nonCollectionLinks.length + component.prop('collections').length;
 
+    expect(actual).toEqual(expected);
+  });
+
+  it('should not render hidden links', () => {
+    const config_with_hidden_links = _.extend(config, {
+      content: {
+        jekyll_admin: {
+          hidden_links: [
+            'posts',
+            'pages'
+          ]
+        }
+      }
+    });
+
+    const { component, links } = setup(Object.assign({}, defaultProps, {
+      config: config_with_hidden_links
+    }));
+
+    const actual = links.length;
+    const expected =
+      (nonCollectionLinks.length - 1) + (component.prop('collections').length - 1);
     expect(actual).toEqual(expected);
   });
 

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -3,16 +3,19 @@ import { mount } from 'enzyme';
 import { Link } from 'react-router';
 import { Sidebar } from '../Sidebar';
 
-import { collections } from './fixtures';
+import { collections, config } from './fixtures';
 
-function setup() {
+const defaultProps = {
+  config: config,
+  collections: collections,
+};
+
+function setup(props=defaultProps) {
   const actions = {
     fetchCollections: jest.fn()
   };
 
-  const component = mount(
-    <Sidebar collections={collections} {...actions} />
-  );
+  const component = mount(<Sidebar {...props} {...actions} />);
 
   return {
     component: component,


### PR DESCRIPTION
Fixes #353 

This PR adds a feature that allows users to hide sidebar links. You can specify the links that you don't want in the sidebar by adding `hidden_links` to `_config.yml`.

**Example**;

```yaml
hidden_links:
  - posts
  - pages
  - ..
``` 