### PR TITLE
Add GUI support to DataFileNew

### DIFF
--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -278,7 +278,8 @@ Simply input the file's basename, the filetype (`YAML` or `JSON`) and data. The 
   clearErrors: Function,
   errors: Array,
   updated: Boolean,
-  datafileChanged: Boolean
+  datafileChanged: Boolean,
+  fieldChanged: Boolean // optional
 }
 ```
 

--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -258,7 +258,10 @@ Container for editing a data file. Supports editing via a raw text editor or a Y
 
 ## DataFileNew
 
-Container for creating a new data file
+Container for creating a new data file.
+
+Includes a *GUI Editor* for easily creating YAML or JSON data files.
+Simply input the file's basename, the filetype (`YAML` or `JSON`) and data. The GUI will create the corresponding file with suitable extensions. CSV files cannot be created via the GUI Editor.
 
 ### PropTypes
 

--- a/src/actions/datafiles.js
+++ b/src/actions/datafiles.js
@@ -39,28 +39,29 @@ export function fetchDataFile(filename) {
 export function putDataFile(filename, data, source = "editor") {
   return (dispatch, getState) => {
     const ext = getExtensionFromPath(filename);
-    let payload = {};
+    let payload;
 
-    if (source == "editor") {
-      const errors = validateDatafile(filename, data);
-      if (errors.length) {
-        return dispatch(validationError(errors));
-      }
-      // clear errors
-      dispatch({type: ActionTypes.CLEAR_ERRORS});
-      payload = { raw_content: data };
-
-    } else if (source == "gui") {
-      const metadata = getState().metadata.metadata;
+    if (source == "gui") {
+      data = getState().metadata.metadata;
       const yaml = /yaml|yml/i.test(ext);
       const json = /json/i.test(ext);
 
       if (yaml) {
-        payload = { raw_content: toYAML(metadata) };
+        payload = { raw_content: toYAML(data) };
       } else if (json) {
-        payload = { raw_content: JSON.stringify(metadata, null, 2) };
+        payload = { raw_content: JSON.stringify(data, null, 2) };
       }
+    } else {
+      payload = { raw_content: data };
     }
+
+    // handle errors
+    const errors = validateDatafile(filename, data);
+    if (errors.length) {
+      return dispatch(validationError(errors));
+    }
+    dispatch({type: ActionTypes.CLEAR_ERRORS});
+
     return put(
       datafileAPIUrl(filename),
       JSON.stringify(payload),

--- a/src/actions/tests/datafiles.spec.js
+++ b/src/actions/tests/datafiles.spec.js
@@ -105,6 +105,42 @@ describe('Actions::Datafiles', () => {
       });
   });
 
+  it('updates a yaml file successfully from the GUI editor', () => {
+    nock(API)
+      .put('/data/data_file.yaml')
+      .reply(200, datafile);
+
+    const expectedAction = [
+      { type: types.CLEAR_ERRORS },
+      { type: types.PUT_DATAFILE_SUCCESS, file: datafile }
+    ];
+
+    const store = mockStore({metadata: { metadata: datafile }});
+
+    return store.dispatch(actions.putDataFile('data_file.yaml', null, 'gui'))
+      .then(() => { // return of async actions
+        expect(store.getActions()).toEqual(expectedAction);
+      });
+  });
+
+  it('updates a json file successfully from the GUI editor', () => {
+    nock(API)
+      .put('/data/data_file.json')
+      .reply(200, datafile);
+
+    const expectedAction = [
+      { type: types.CLEAR_ERRORS },
+      { type: types.PUT_DATAFILE_SUCCESS, file: datafile }
+    ];
+
+    const store = mockStore({metadata: { metadata: datafile }});
+
+    return store.dispatch(actions.putDataFile('data_file.json', null, 'gui'))
+      .then(() => { // return of async actions
+        expect(store.getActions()).toEqual(expectedAction);
+      });
+  });
+
   it('creates PUT_DATAFILE_FAILURE when updating a datafile failed', () => {
     nock(API)
       .put('/data/data_file.yml', datafile)
@@ -173,5 +209,18 @@ describe('Actions::Datafiles', () => {
 
     store.dispatch(actions.putDataFile());
     expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('creates DATAFILE_CHANGED when the content in editor is changed', () => {
+    const expectedAction = [
+      {
+        type: types.DATAFILE_CHANGED
+      }
+    ];
+
+    const store = mockStore({ config: {} });
+
+    store.dispatch(actions.onDataFileChanged());
+    expect(store.getActions()).toEqual(expectedAction);
   });
 });

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -30,7 +30,12 @@ export class DataFileNew extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
-      const filename = this.refs.inputpath.refs.input.value;
+      let filename;
+      if (this.state.guiView) {
+        filename = this.refs.filename.value + this.refs.datatype.value;
+      } else {
+        filename = this.refs.inputpath.refs.input.value;
+      }
       browserHistory.push(`${ADMIN_PREFIX}/datafiles/${filename}`);
     }
   }
@@ -44,7 +49,7 @@ export class DataFileNew extends Component {
   }
 
   routerWillLeave(nextLocation) {
-    if (this.props.datafileChanged) {
+    if (!this.state.guiView && this.props.datafileChanged) {
       return getLeaveMessage();
     }
   }
@@ -53,17 +58,53 @@ export class DataFileNew extends Component {
     this.setState({ guiView: !this.state.guiView });
   }
 
+  handleChange(e) {
+    const { onDataFileChanged } = this.props;
+    (e.target.value);
+    onDataFileChanged();
+  }
+
   handleClickSave() {
     const { datafileChanged, putDataFile } = this.props;
-
+    let filename;
     if (datafileChanged) {
-      const filename = this.refs.inputpath.refs.input.value;
       if (this.state.guiView) {
+        filename = this.refs.filename.value + this.refs.datatype.value;
         putDataFile(filename, null, "gui");
       } else {
+        filename = this.refs.inputpath.refs.input.value;
         putDataFile(filename, this.refs.editor.getValue());
       }
     }
+  }
+
+  renderGUInputs() {
+    return(
+      <form className="datafile-path">
+        <fieldset className="directory">
+          <legend>Directory</legend>
+          <input
+            type="text"
+            placeholder="directory"
+            disabled />
+        </fieldset>
+        <fieldset className="filename">
+          <legend>Filename (without extension)</legend>
+          <input
+            type="text"
+            ref="filename"
+            onChange={(e) => this.handleChange(e)}
+            placeholder="filename" />
+        </fieldset>
+        <fieldset className="file-type">
+          <legend>File Type</legend>
+          <select ref="datatype">
+            <option value=".yml">YAML</option>
+            <option value=".json">JSON</option>
+          </select>
+        </fieldset>
+      </form>
+    );
   }
 
   render() {
@@ -80,21 +121,23 @@ export class DataFileNew extends Component {
 
         <div className="content-wrapper">
           <div className="content-body">
-            <InputPath
-              onChange={onDataFileChanged}
-              type="datafiles"
-              path=""
-              ref="inputpath" />
             {
-              this.state.guiView && <DataGUI fields={{"Key": "Value"}} dataview />
+              this.state.guiView && <div>
+                {this.renderGUInputs()}
+                <DataGUI fields={{"key": "value"}} dataview /></div>
             }
             {
-              !this.state.guiView &&
+              !this.state.guiView && <div>
+                <InputPath
+                  onChange={onDataFileChanged}
+                  type="datafiles"
+                  path=""
+                  ref="inputpath" />
                 <Editor
                   editorChanged={datafileChanged}
                   onEditorChange={onDataFileChanged}
                   content={""}
-                  ref="editor" />
+                  ref="editor" /></div>
             }
           </div>
 

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
+import DataGUI from '../MetaFields';
 import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
 import Button from '../../components/Button';
@@ -13,6 +14,14 @@ import { getLeaveMessage } from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DataFileNew extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      guiView: false
+    };
+  }
 
   componentDidMount() {
     const { router, route } = this.props;
@@ -40,12 +49,20 @@ export class DataFileNew extends Component {
     }
   }
 
+  toggleView() {
+    this.setState({ guiView: !this.state.guiView });
+  }
+
   handleClickSave() {
     const { datafileChanged, putDataFile } = this.props;
+
     if (datafileChanged) {
       const filename = this.refs.inputpath.refs.input.value;
-      const value = this.refs.editor.getValue();
-      putDataFile(filename, value);
+      if (this.state.guiView) {
+        putDataFile(filename, null, "gui");
+      } else {
+        putDataFile(filename, this.refs.editor.getValue());
+      }
     }
   }
 
@@ -68,14 +85,26 @@ export class DataFileNew extends Component {
               type="datafiles"
               path=""
               ref="inputpath" />
-            <Editor
-              editorChanged={datafileChanged}
-              onEditorChange={onDataFileChanged}
-              content={''}
-              ref="editor" />
+            {
+              this.state.guiView && <DataGUI fields={{"Key": "Value"}} dataview />
+            }
+            {
+              !this.state.guiView &&
+                <Editor
+                  editorChanged={datafileChanged}
+                  onEditorChange={onDataFileChanged}
+                  content={""}
+                  ref="editor" />
+            }
           </div>
 
           <div className="content-side">
+            <Button
+              onClick={this.toggleView.bind(this)}
+              type="view-toggle"
+              active={true}
+              triggered={this.state.guiView}
+              block />
             <Button
               onClick={() => this.handleClickSave()}
               type="create"

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -19,7 +19,11 @@ export class DataFileNew extends Component {
 
   constructor(props) {
     super(props);
+
+    this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
+    this.toggleView = this.toggleView.bind(this);
+
     this.state = {
       guiView: false
     };
@@ -27,7 +31,7 @@ export class DataFileNew extends Component {
 
   componentDidMount() {
     const { router, route } = this.props;
-    router.setRouteLeaveHook(route, this.routerWillLeave.bind(this));
+    router.setRouteLeaveHook(route, this.routerWillLeave);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -153,13 +157,13 @@ export class DataFileNew extends Component {
 
           <div className="content-side">
             <Button
-              onClick={this.toggleView.bind(this)}
+              onClick={this.toggleView}
               type="view-toggle"
               active={true}
               triggered={this.state.guiView}
               block />
             <Button
-              onClick={() => this.handleClickSave()}
+              onClick={this.handleClickSave}
               type="create"
               active={datafileChanged}
               triggered={updated}

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -23,9 +23,12 @@ export class DataFileNew extends Component {
     this.routerWillLeave = this.routerWillLeave.bind(this);
     this.handleClickSave = this.handleClickSave.bind(this);
     this.toggleView = this.toggleView.bind(this);
+    this.handleChange = this.handleChange.bind(this);
 
     this.state = {
-      guiView: false
+      guiView: false,
+      baseName: '',
+      extn: '.yml'
     };
   }
 
@@ -38,7 +41,7 @@ export class DataFileNew extends Component {
     if (this.props.updated !== nextProps.updated) {
       let filename;
       if (this.state.guiView) {
-        filename = this.refs.filename.value + this.refs.datatype.value;
+        filename = this.state.baseName + this.state.extn;
       } else {
         filename = this.refs.inputpath.refs.input.value;
       }
@@ -66,7 +69,12 @@ export class DataFileNew extends Component {
 
   handleChange(e) {
     const { onDataFileChanged } = this.props;
-    (e.target.value);
+    let obj = {};
+    const key = e.target.id;
+    const value = e.target.value;
+    obj[key] = value;
+
+    this.setState(obj);
     onDataFileChanged();
   }
 
@@ -79,7 +87,7 @@ export class DataFileNew extends Component {
     let filename;
     if (datafileChanged) {
       if (this.state.guiView) {
-        filename = this.refs.filename.value + this.refs.datatype.value;
+        filename = this.state.baseName + this.state.extn;
         putDataFile(filename, null, "gui");
       } else {
         filename = this.refs.inputpath.refs.input.value;
@@ -102,13 +110,13 @@ export class DataFileNew extends Component {
           <legend>Filename (without extension)</legend>
           <input
             type="text"
-            ref="filename"
-            onChange={(e) => this.handleChange(e)}
+            id="baseName"
+            onChange={this.handleChange}
             placeholder="filename" />
         </fieldset>
         <fieldset className="file-type">
           <legend>File Type</legend>
-          <select ref="datatype">
+          <select id="extn" value={this.state.extn} onChange={this.handleChange}>
             <option value=".yml">YAML</option>
             <option value=".json">JSON</option>
           </select>
@@ -119,12 +127,20 @@ export class DataFileNew extends Component {
 
   render() {
     const {
-      datafileChanged, onDataFileChanged, updated, errors
+      datafileChanged, fieldChanged, onDataFileChanged, updated, errors
     } = this.props;
 
     const keyboardHandlers = {
       'save': this.handleClickSave,
     };
+
+    // activate or deactivate `Create` button based on various states
+    let activator = false;
+    if (this.state.guiView && this.state.baseName) {
+      activator = datafileChanged || fieldChanged;
+    } else if (!this.state.guiView) {
+      activator = datafileChanged;
+    }
 
     return (
       <HotKeys handlers={keyboardHandlers}>
@@ -165,7 +181,7 @@ export class DataFileNew extends Component {
             <Button
               onClick={this.handleClickSave}
               type="create"
-              active={datafileChanged}
+              active={activator}
               triggered={updated}
               icon="plus-square"
               block />
@@ -185,13 +201,15 @@ DataFileNew.propTypes = {
   updated: PropTypes.bool.isRequired,
   datafileChanged: PropTypes.bool.isRequired,
   router: PropTypes.object.isRequired,
-  route: PropTypes.object.isRequired
+  route: PropTypes.object.isRequired,
+  fieldChanged: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({
   datafile: state.datafiles.currentFile,
   updated: state.datafiles.updated,
   datafileChanged: state.datafiles.datafileChanged,
+  fieldChanged: state.metadata.fieldChanged,
   errors: state.utils.errors
 });
 

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -79,13 +79,13 @@ export class DataFileNew extends Component {
   }
 
   handleClickSave(e) {
-    const { datafileChanged, putDataFile } = this.props;
+    const { datafileChanged, fieldChanged, putDataFile } = this.props;
 
     // Prevent the default event from bubbling
     preventDefault(e);
 
     let filename;
-    if (datafileChanged) {
+    if (datafileChanged || fieldChanged) {
       if (this.state.guiView) {
         filename = this.state.baseName + this.state.extn;
         putDataFile(filename, null, "gui");

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, withRouter } from 'react-router';
+import { HotKeys } from 'react-hotkeys';
 import DataGUI from '../MetaFields';
 import Errors from '../../components/Errors';
 import Editor from '../../components/Editor';
@@ -10,6 +11,7 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import InputPath from '../../components/form/InputPath';
 import { putDataFile, onDataFileChanged } from '../../actions/datafiles';
 import { clearErrors } from '../../actions/utils';
+import { preventDefault } from '../../utils/helpers';
 import { getLeaveMessage } from '../../constants/lang';
 import { ADMIN_PREFIX } from '../../constants';
 
@@ -17,7 +19,7 @@ export class DataFileNew extends Component {
 
   constructor(props) {
     super(props);
-
+    this.handleClickSave = this.handleClickSave.bind(this);
     this.state = {
       guiView: false
     };
@@ -64,8 +66,12 @@ export class DataFileNew extends Component {
     onDataFileChanged();
   }
 
-  handleClickSave() {
+  handleClickSave(e) {
     const { datafileChanged, putDataFile } = this.props;
+
+    // Prevent the default event from bubbling
+    preventDefault(e);
+
     let filename;
     if (datafileChanged) {
       if (this.state.guiView) {
@@ -112,8 +118,12 @@ export class DataFileNew extends Component {
       datafileChanged, onDataFileChanged, updated, errors
     } = this.props;
 
+    const keyboardHandlers = {
+      'save': this.handleClickSave,
+    };
+
     return (
-      <div>
+      <HotKeys handlers={keyboardHandlers}>
         {errors.length > 0 && <Errors errors={errors} />}
         <div className="content-header">
           <Breadcrumbs splat="" type="datafiles" />
@@ -157,7 +167,7 @@ export class DataFileNew extends Component {
               block />
           </div>
         </div>
-      </div>
+      </HotKeys>
     );
   }
 }

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import { DataFileNew } from '../DataFileNew';
-
 import Button from '../../../components/Button';
+import Editor from '../../../components/Editor';
+import Errors from '../../../components/Errors';
+import DataGUI from '../../../containers/MetaFields';
 
 const defaultProps = {
   datafile: {},
@@ -27,19 +28,43 @@ const setup = (props = defaultProps) => {
   return {
     component,
     actions,
-    saveButton: component.find(Button),
+    toggleButton: component.find(Button).first(),
+    saveButton: component.find(Button).last(),
+    editor: component.find(Editor).first(),
+    gui: component.find(DataGUI).first(),
+    errors: component.find(Errors),
     props
   };
 };
 
 describe('Containers::DataFileNew', () => {
+  it('should render correctly', () => {
+    const { component, toggleButton, saveButton, editor, gui } = setup();
+    expect(toggleButton.node.props['type']).toEqual('view-toggle');
+    expect(saveButton.node.props['type']).toEqual('create');
+    expect(editor.node.props['content']).toEqual('');
+    expect(gui.node).toBeFalsy();
+  });
+
+  it('should not render error messages initially', () => {
+    const { errors } = setup();
+    expect(errors.node).toBeFalsy();
+  });
+
+  it('should render error messages', () => {
+    const { errors } = setup(Object.assign({}, defaultProps, {
+      errors: ['The content is required!']
+    }));
+    expect(errors.node).toBeTruthy();
+  });
+
   it('should not call putDataFile if a field is not changed.', () => {
     const { saveButton, actions } = setup();
     saveButton.simulate('click');
     expect(actions.putDataFile).not.toHaveBeenCalled();
   });
 
-  it('should call activate save button if a field is changed.', () => {
+  it('should activate save button if a field is changed.', () => {
     const { saveButton } = setup(Object.assign({}, defaultProps, {
       datafileChanged: true
     }));

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -43,7 +43,7 @@ describe('Containers::DataFileNew', () => {
     expect(toggleButton.node.props['type']).toEqual('view-toggle');
     expect(saveButton.node.props['type']).toEqual('create');
     expect(editor.node.props['content']).toEqual('');
-    expect(component.state()).toEqual({'guiView': false});
+    expect(component.state()).toEqual({'baseName': '', 'extn': '.yml', 'guiView': false});
   });
 
   it('should not render error messages initially', () => {
@@ -85,7 +85,7 @@ describe('Containers::DataFileNew', () => {
     expect(actions.putDataFile).not.toHaveBeenCalled();
   });
 
-  it('should activate save button if a field is changed.', () => {
+  it('should activate save button when Editor or input field is changed.', () => {
     const { saveButton } = setup(Object.assign({}, defaultProps, {
       datafileChanged: true
     }));

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -39,11 +39,11 @@ const setup = (props = defaultProps) => {
 
 describe('Containers::DataFileNew', () => {
   it('should render correctly', () => {
-    const { component, toggleButton, saveButton, editor, gui } = setup();
+    const { component, toggleButton, saveButton, editor } = setup();
     expect(toggleButton.node.props['type']).toEqual('view-toggle');
     expect(saveButton.node.props['type']).toEqual('create');
     expect(editor.node.props['content']).toEqual('');
-    expect(gui.node).toBeFalsy();
+    expect(component.state()).toEqual({'guiView': false});
   });
 
   it('should not render error messages initially', () => {
@@ -56,6 +56,27 @@ describe('Containers::DataFileNew', () => {
       errors: ['The content is required!']
     }));
     expect(errors.node).toBeTruthy();
+  });
+
+  it('should not call clearErrors on unmount if there are no errors.', () => {
+    const { component, errors, actions } = setup();
+    component.unmount();
+    expect(actions.clearErrors).not.toHaveBeenCalled();
+  });
+
+  it('should clear errors on unmount.', () => {
+    const { component, errors, actions } = setup(Object.assign({}, defaultProps, {
+      errors: ['The content is required!']
+    }));
+    component.unmount();
+    expect(actions.clearErrors).toHaveBeenCalled();
+  });
+
+  it('should toggle views.', () => {
+    const { component, toggleButton } = setup();
+    expect(component.state('guiView')).toBe(false);
+    toggleButton.simulate('click');
+    expect(component.state('guiView')).toBe(true);
   });
 
   it('should not call putDataFile if a field is not changed.', () => {

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -123,3 +123,44 @@
     @include translateX(20px);
   }
 }
+
+.datafile-path {
+  margin-bottom: 8px;
+
+  fieldset {
+    display: inline-block;
+    margin: 0 4px;
+    padding: 0;
+    border-radius: 5px;
+    border-color: transparent;
+
+    &.directory { width: 53%; }
+    &.filename { width: 30%; }
+    &.file-type { width: 15%; }
+
+    &:first-of-type { margin-left: 0; }
+    &:last-of-type { margin-right: 0; }
+  }
+
+  legend {
+    margin-bottom: 8px;
+    font-weight: 700;
+  }
+
+  input, select {
+    min-height: 46px;
+    padding: 11px 10px;
+    width: 100%;
+    color: white;
+    background-color: #2b2b2b;
+    border: 1px solid transparent;
+    border-radius: 2px;
+  }
+
+  input {
+    &:disabled { background-color: #4d4d4d; }
+    &:focus { outline: none; border-color: $dark-orange; }
+  }
+
+  select { font-size: 15px; }
+}

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -162,5 +162,37 @@
     &:focus { outline: none; border-color: $dark-orange; }
   }
 
-  select { font-size: 15px; }
+  select {
+    font-size: 15px;
+    color: #ddd;
+    cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+
+    &:focus { outline: none; border-color: $dark-orange; }
+
+    option {
+      min-height: 21px;
+      &:hover { background-color: $dark-orange; }
+    }
+  }
+
+  .file-type {
+    legend {
+      position: relative;
+
+      // custom dropdown arrow
+      &:after {
+        content: "\25BC";
+        position: absolute;
+        top: 28px;
+        right: -54px;
+        padding: 12px 9px;
+        color: #bbb;
+        vertical-align: middle;
+        pointer-events: none;
+        border-left: 1px solid #454545;
+      }
+    }
+  }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -52,6 +52,10 @@ b {
   color: $orange;
 }
 
+div:focus {
+  outline: none;
+}
+
 .wrapper {
   height: 100%;
 


### PR DESCRIPTION
- [x] add GUI to `DataFileNew`
- [x] update spec file for view
- [x] lock GUI support to just YAML and JSON files
    - ~~**Either** listen to `InputPath` value and disable `createButton`,~~
    - **or** add a form component to **`select`** the file extension.
- [x] update documentation