### PR TITLE
Don't trim spaces from metadata value-field

### DIFF
--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -38,6 +38,11 @@ export class MetaSimple extends Component {
     updateFieldValue(nameAttr, e.target.value);
   }
 
+  handleEditableBlur(e) {
+    const { nameAttr, updateFieldValue } = this.props;
+    updateFieldValue(nameAttr, e.target.value.trim());
+  }
+
   handleDatepickerChange(date, dateStr) {
     const { nameAttr, updateFieldValue } = this.props;
     let formatted = moment(date).format("YYYY-MM-DD hh:mm:ss");
@@ -49,6 +54,7 @@ export class MetaSimple extends Component {
     return (
       <TextareaAutosize
         onChange={(e) => this.handleEditableChange(e)}
+        onBlur={(e) => this.handleEditableBlur(e)}
         className="field value-field"
         value={`${fieldValue}`} />
     );

--- a/src/components/metadata/tests/metasimple.spec.js
+++ b/src/components/metadata/tests/metasimple.spec.js
@@ -48,4 +48,10 @@ describe('Components::MetaSimple', () => {
     editable.simulate('change');
     expect(actions.updateFieldValue).toHaveBeenCalled();
   });
+
+  it('should call updateFieldValue when the input field is blurred', () => {
+    const { actions, editable } = setup();
+    editable.simulate('blur');
+    expect(actions.updateFieldValue).toHaveBeenCalled();
+  });
 });

--- a/src/reducers/metadata.js
+++ b/src/reducers/metadata.js
@@ -78,7 +78,7 @@ export default function metadata(state = {
         metadata: updateFieldValue(
           state,
           action.nameAttr,
-          action.value.trim()
+          action.value
         ),
         fieldChanged: true
       });

--- a/src/reducers/tests/metadata.spec.js
+++ b/src/reducers/tests/metadata.spec.js
@@ -148,7 +148,7 @@ describe('Reducers::Metadata', () => {
     ).toEqual({
       metadata: {
         ...meta,
-        notexists: 'willExist'
+        notexists: '  willExist  '
       },
       new_field_count: 0,
       fieldChanged: true


### PR DESCRIPTION
Fixes #364 
A regression was caused by #339 wherein the eventhandler attached to `.value-field` prevents typing a space character before the next word.

`<TextareaAutosize />` doesn't have an `onBlur` prop to dispatch trimming effectively. So simply reverting to old behavior.
