### PR TITLE
send extracted config hash to main container components

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -36,14 +36,19 @@ class App extends Component {
       <HotKeys
         keyMap={keyboardShortcuts}
         className="wrapper">
-        <Sidebar config={config} />
-        <div className="container">
-          <Header config={config} />
-          <div className="content">
-            {this.props.children}
+        {
+          config.content &&
+          <div>
+            <Sidebar config={config.content} />
+            <div className="container">
+              <Header config={config.content} />
+              <div className="content">
+                {this.props.children}
+              </div>
+            </div>
+            <Notifications />
           </div>
-        </div>
-        <Notifications />
+        }
       </HotKeys>
     );
   }

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -8,15 +8,12 @@ export class Header extends Component {
 
   render() {
     const { config } = this.props;
-    const configuration = config.content;
     return (
       <div className="header">
         <h3 className="title">
-          <Link target="_blank" to="/">
+          <Link target="_blank" to={config.url || "/"}>
             <i className="fa fa-home" />
-            {
-              configuration && <span>{configuration.title || 'You have no title!'}</span>
-            }
+            <span>{config.title || "You have no title!"}</span>
           </Link>
         </h3>
         <span className="version">{VERSION}</span>

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -38,7 +38,6 @@ export class Sidebar extends Component {
 
   render() {
     const { config } = this.props;
-    const content = config.content;
 
     const defaults = {
       pages: {
@@ -68,7 +67,7 @@ export class Sidebar extends Component {
     const defaultLinks = _.keys(defaults);
     let hiddenLinks;
     try {
-      hiddenLinks = config.content.jekyll_admin.hidden_links;
+      hiddenLinks = config.jekyll_admin.hidden_links;
     } catch (e) {
       hiddenLinks = [];
     }

--- a/src/containers/tests/header.spec.js
+++ b/src/containers/tests/header.spec.js
@@ -5,9 +5,9 @@ import { Header } from '../Header';
 import { config } from './fixtures';
 
 function setup() {
-
+  const siteConfig = config.content;
   const component = mount(
-    <Header config={config} />
+    <Header config={siteConfig} />
   );
 
   return {
@@ -18,10 +18,8 @@ function setup() {
 
 describe('Containers::Header', () => {
   it('should render correctly', () => {
-    const { title } = setup();
-    const { content } = config;
-    const actual = title.text();
-    const expected = content.title;
-    expect(actual).toEqual(expected);
+    const { component, title } = setup();
+    const { config } = component.props();
+    expect(title.text()).toEqual(config.title);
   });
 });

--- a/src/containers/tests/header.spec.js
+++ b/src/containers/tests/header.spec.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Header } from '../Header';
-
 import { config } from './fixtures';
 
-function setup() {
-  const siteConfig = config.content;
+const defaultProps = { config: config.content };
+
+function setup(props = defaultProps) {
   const component = mount(
-    <Header config={siteConfig} />
+    <Header {...props} />
   );
 
   return {
@@ -21,5 +21,13 @@ describe('Containers::Header', () => {
     const { component, title } = setup();
     const { config } = component.props();
     expect(title.text()).toEqual(config.title);
+  });
+
+  it('should render placeholder title', () => {
+    const { component, title } = setup(Object.assign({}, defaultProps, {
+      config: {}
+    }));
+    const { config } = component.props();
+    expect(title.text()).toEqual('You have no title!');
   });
 });

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -13,7 +13,7 @@ const defaultProps = {
 
 const nonCollectionLinks = ['pages', 'datafiles', 'staticfiles', 'configuration'];
 
-function setup(props=defaultProps) {
+function setup(props = defaultProps) {
   const actions = {
     fetchCollections: jest.fn()
   };
@@ -38,13 +38,11 @@ describe('Containers::Sidebar', () => {
 
   it('should not render hidden links', () => {
     const config_with_hidden_links = _.extend(config, {
-      content: {
-        jekyll_admin: {
-          hidden_links: [
-            'posts',
-            'pages'
-          ]
-        }
+      jekyll_admin: {
+        hidden_links: [
+          'posts',
+          'pages'
+        ]
       }
     });
 

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -60,4 +60,14 @@ describe('Containers::Sidebar', () => {
     const { actions } = setup();
     expect(actions.fetchCollections).toHaveBeenCalled();
   });
+
+  it('should render fine with zero collections', () => {
+    const { component, links, actions } = setup(Object.assign({}, defaultProps, {
+      collections: [],
+      config: {
+        jekyll_admin: {}
+      }
+    }));
+    expect(links.length).toEqual(4);
+  });
 });


### PR DESCRIPTION
send `config.content` to `<Header/>` and `<Sidebar/>` instead of extracting the config hash from within these components