### PR TITLE
Style messages from `Errors`

### DIFF
--- a/src/components/Errors.js
+++ b/src/components/Errors.js
@@ -2,9 +2,9 @@ import React, { PropTypes} from 'react';
 import _ from 'underscore';
 
 const Errors = ({errors}) => (
-  <ul className="error-messages">
-    {_.map(errors, (error,i) => <li key={i}>{error}</li>)}
-  </ul>
+  <div className="error-messages">
+    {_.map(errors, (error,i) => <div key={i}>{error}</div>)}
+  </div>
 );
 
 Errors.propTypes = {

--- a/src/components/tests/errors.spec.js
+++ b/src/components/tests/errors.spec.js
@@ -11,13 +11,13 @@ function setup() {
 
   return {
     component,
-    listItem: component.find('li')
+    errorItems: component.find('.error-messages > div')
   };
 }
 
 describe('Components::Errors', () => {
   it('should render errors correctly', () => {
-    const { listItem } = setup();
-    expect(listItem.length).toBe(errors.length);
+    const { errorItems } = setup();
+    expect(errorItems.length).toEqual(errors.length);
   });
 });

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -156,14 +156,22 @@
     }
   }
   .error-messages {
-    color: $dark-red;
-    padding: 0 10px 0 20px;
     margin-bottom: 40px;
+    padding: 10px 15px;
     font-size: 18px;
-    li{
+    color: $dark-red;
+    background-color: lighten($dark-red, 37%);
+
+    div {
       padding: 10px 0;
+      &:before {
+        content: "\f071";
+        font-family: "FontAwesome";
+        margin-right: 5px;
+      }
     }
   }
+
   .splitter {
     margin: 15px 0;
     background: #cfcfcf;


### PR DESCRIPTION
### Demo:
![errors](https://cloud.githubusercontent.com/assets/12479464/26031948/84feb1d8-38a3-11e7-89e6-0c90fc6b047e.png)
