### PR TITLE
Fix returning <h1> when a data file is empty

### DIFF
--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -119,8 +119,8 @@ export class DataFileEdit extends Component {
       return null;
     }
 
-    if (_.isEmpty(datafile)) {
-      return <h1>{getNotFoundMessage("data file")}</h1>;
+    if (_.isEmpty(datafile.content)) {
+      return <h1>{getNotFoundMessage("content")}</h1>;
     }
 
     const { path, raw_content, content } = datafile;


### PR DESCRIPTION
We're currently checking if `datafile` is empty. Instead we should check if `datafile.content` is empty.
Also IMO, **`No content found.`** sounds better than **`No data file found.`**