### PR TITLE
Remove shouldComponentUpdate from MetaSimple component

### DIFF
--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -21,10 +21,6 @@ export class MetaSimple extends Component {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.fieldValue !== this.props.fieldValue;
-  }
-
   handleOpenModal () {
     this.setState({ showModal: true });
   }


### PR DESCRIPTION
This is not needed after switching to [controlled inputs](https://facebook.github.io/react/docs/forms.html#controlled-components) and it prevents re-rendering on state change which causes `StaticFilePicker` to not show up.