### PR TITLE
Warn user that `--watch` has been disabled

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -16,6 +16,8 @@ module Jekyll
         def jekyll_admin_monkey_patch(server)
           server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
           server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
+          Jekyll.logger.warn "Auto-regeneration:", "disabled by JekyllAdmin."
+          Jekyll.logger.warn "", "The site will regenerate only via the Admin interface."
           Jekyll.logger.info "JekyllAdmin mode:", ENV["RACK_ENV"] || "production"
         end
       end


### PR DESCRIPTION
In light of numerous questions popped regarding failed auto-regeneration, at `jekyll/jekyll` and `StackOverflow`, this adds a `WARN` level logger message to inform users that auto-regeneration has been disabled and will only trigger via the admin interface.

```
 Auto-regeneration: disabled by JekyllAdmin.
                    The site will regenerate only via the Admin interface.
  JekyllAdmin mode: development
    Server address: http://127.0.0.1:4000/
```

IMO we should ship a `0.5.1` with this **a.s.a.p**

/cc @mertkahyaoglu @benbalter 