### PR TITLE
Sticky side buttons

### DIFF
--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -183,29 +183,31 @@ export class DataFileEdit extends Component {
 
     return (
       <div className="content-side">
-        <Button
-          onClick={this.handleClickSave}
-          type="save"
-          active={activator}
-          triggered={updated}
-          icon="save"
-          block />
-        {
-          guiSupport &&
-            <Button
-              onClick={this.toggleView}
-              type="view-toggle"
-              active={true}
-              triggered={this.state.guiView}
-              block />
-        }
-        <Splitter />
-        <Button
-          onClick={() => this.handleClickDelete(filename)}
-          type="delete"
-          active={true}
-          icon="trash"
-          block />
+        <div className="sticky">
+          <Button
+            onClick={this.handleClickSave}
+            type="save"
+            active={activator}
+            triggered={updated}
+            icon="save"
+            block />
+          {
+            guiSupport &&
+              <Button
+                onClick={this.toggleView}
+                type="view-toggle"
+                active={true}
+                triggered={this.state.guiView}
+                block />
+          }
+          <Splitter />
+          <Button
+            onClick={() => this.handleClickDelete(filename)}
+            type="delete"
+            active={true}
+            icon="trash"
+            block />
+        </div>
       </div>
     );
   }

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -160,19 +160,21 @@ export class DataFileNew extends Component {
           </div>
 
           <div className="content-side">
-            <Button
-              onClick={this.handleClickSave}
-              type="create"
-              active={activator}
-              triggered={updated}
-              icon="plus-square"
-              block />
-            <Button
-              onClick={this.toggleView}
-              type="view-toggle"
-              active={true}
-              triggered={this.state.guiView}
-              block />
+            <div className="sticky">
+              <Button
+                onClick={this.handleClickSave}
+                type="create"
+                active={activator}
+                triggered={updated}
+                icon="plus-square"
+                block />
+              <Button
+                onClick={this.toggleView}
+                type="view-toggle"
+                active={true}
+                triggered={this.state.guiView}
+                block />
+            </div>
           </div>
         </div>
       </HotKeys>

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -147,29 +147,31 @@ export class DocumentEdit extends Component {
           </div>
 
           <div className="content-side">
-            <Button
-              onClick={this.handleClickSave}
-              type="save"
-              active={fieldChanged}
-              triggered={updated}
-              icon="save"
-              block />
-            {
-              http_url &&
-                <Button
-                  to={http_url}
-                  type="view"
-                  icon="eye"
-                  active={true}
-                  block />
-            }
-            <Splitter />
-            <Button
-              onClick={() => this.handleClickDelete()}
-              type="delete"
-              active={true}
-              icon="trash"
-              block />
+            <div className="sticky">
+              <Button
+                onClick={this.handleClickSave}
+                type="save"
+                active={fieldChanged}
+                triggered={updated}
+                icon="save"
+                block />
+              {
+                http_url &&
+                  <Button
+                    to={http_url}
+                    type="view"
+                    icon="eye"
+                    active={true}
+                    block />
+              }
+              <Splitter />
+              <Button
+                onClick={() => this.handleClickDelete()}
+                type="delete"
+                active={true}
+                icon="trash"
+                block />
+            </div>
           </div>
         </div>
       </HotKeys>

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -106,13 +106,15 @@ export class DocumentNew extends Component {
           </div>
 
           <div className="content-side">
-            <Button
-              onClick={this.handleClickSave}
-              type="create"
-              active={fieldChanged}
-              triggered={updated}
-              icon="plus-square"
-              block />
+            <div className="sticky">
+              <Button
+                onClick={this.handleClickSave}
+                type="create"
+                active={fieldChanged}
+                triggered={updated}
+                icon="plus-square"
+                block />
+            </div>
           </div>
         </div>
       </HotKeys>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -133,26 +133,28 @@ export class PageEdit extends Component {
           </div>
 
           <div className="content-side">
-            <Button
-              onClick={this.handleClickSave}
-              type="save"
-              active={fieldChanged}
-              triggered={updated}
-              icon="save"
-              block />
-            <Button
-              to={http_url}
-              type="view"
-              icon="eye"
-              active={true}
-              block />
-            <Splitter />
-            <Button
-              onClick={() => this.handleClickDelete(name)}
-              type="delete"
-              active={true}
-              icon="trash"
-              block />
+            <div className="sticky">
+              <Button
+                onClick={this.handleClickSave}
+                type="save"
+                active={fieldChanged}
+                triggered={updated}
+                icon="save"
+                block />
+              <Button
+                to={http_url}
+                type="view"
+                icon="eye"
+                active={true}
+                block />
+              <Splitter />
+              <Button
+                onClick={() => this.handleClickDelete(name)}
+                type="delete"
+                active={true}
+                icon="trash"
+                block />
+            </div>
           </div>
         </div>
       </HotKeys>

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -98,13 +98,15 @@ export class PageNew extends Component {
           </div>
 
           <div className="content-side">
-            <Button
-              onClick={this.handleClickSave}
-              type="create"
-              active={fieldChanged}
-              triggered={updated}
-              icon="plus-square"
-              block />
+            <div className="sticky">
+              <Button
+                onClick={this.handleClickSave}
+                type="create"
+                active={fieldChanged}
+                triggered={updated}
+                icon="plus-square"
+                block />
+            </div>
           </div>
         </div>
       </HotKeys>

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -126,6 +126,7 @@
       }
     }
     .content-side {
+      position: relative;
       width: $content-side-width;
       margin-left: 40px;
       font-size: 16px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -99,6 +99,11 @@ div:focus {
   }
 }
 
+.sticky {
+  position: sticky;
+  top: 0;
+}
+
 @font-face {
   font-family: "lato";
   src: url(../assets/fonts/lato-regular.ttf);


### PR DESCRIPTION
With this PR, side buttons follow you when you scroll to the bottom of a page using the new css attribute `position: sticky`. This is not fully [supported](http://caniuse.com/css-sticky/embed/) by browsers but it's better than nothing.

Fixes #388 
