### PR TITLE
Write files with binary mode

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -18,7 +18,9 @@ module JekyllAdmin
       Jekyll.logger.debug "WRITING:", path
       path = sanitized_path(path)
       FileUtils.mkdir_p File.dirname(path)
-      File.write(path, content)
+      File.open(path, "wb") do |file|
+        file.write(content)
+      end
       site.process
     end
 


### PR DESCRIPTION
Fix #404 
Fix regression introduced in [`b4a8ff9`](https://github.com/jekyll/jekyll-admin/pull/323/commits/b4a8ff98e10fd47beffed7a74ba040a6b5fc0c67)