### PR TITLE
allows for default content to be set in config file

### DIFF
--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -119,6 +119,7 @@ export class DocumentEdit extends Component {
       front_matter,
       name,
     } = currentDocument;
+
     const [directory, ...rest] = params.splat;
 
     const metafields = injectDefaultFields(
@@ -135,6 +136,10 @@ export class DocumentEdit extends Component {
     const document_title = directory
       ? `${title} - ${directory} - ${capitalize(collection)}`
       : `${title} - ${capitalize(collection)}`;
+
+    let confcon = config.content;
+    let config_field = Object.keys(confcon).indexOf("default_content") != -1 ? confcon.default_content[collection] : undefined;
+    let initial_value = raw_content != '' ? raw_content : config_field != undefined ? config_field : '';
 
     return (
       <DocumentTitle title={document_title}>
@@ -153,7 +158,7 @@ export class DocumentEdit extends Component {
                 onChange={updateBody}
                 onSave={this.handleClickSave}
                 placeholder="Body"
-                initialValue={raw_content}
+                initialValue={initial_value}
                 ref="editor"
               />
               <Splitter />

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -84,6 +84,10 @@ export class DocumentNew extends Component {
       ? `New document - ${params.splat} - ${capitalize(collection)}`
       : `New document - ${capitalize(collection)}`;
 
+    let confcon = config.content;
+    let config_field = Object.keys(confcon).indexOf("default_content") != -1 ? confcon.default_content[collection] : undefined;
+    let initial_value =  config_field != undefined ? config_field : "";
+
     return (
       <DocumentTitle title={document_title}>
         <HotKeys handlers={keyboardHandlers} className="single">
@@ -101,7 +105,7 @@ export class DocumentNew extends Component {
                 onChange={updateBody}
                 onSave={this.handleClickSave}
                 placeholder="Body"
-                initialValue=""
+                initialValue={initial_value}
                 ref="editor"
               />
               <Splitter />


### PR DESCRIPTION
This PR allows for default content to be set when creating a new document. This information get set in the config file and is defined based upon collection name. i.e. 
```
default_content: {
  puppies: "<div id='biography' markdown='1'>\n\n</div>\n<div id='bibliography' markdown='1'>\n\n</div>"
}
```