### PR TITLE
The data files are getting deleted when editing in Raw Editor, fix #482

### DIFF
--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -29,7 +29,7 @@ describe "data" do
   it "gets the index" do
     get "/data"
     expect(last_response).to be_ok
-    expect(last_response_parsed[2]).to eql(base_response)
+    expect(last_response_parsed.select { |file| file["slug"] === "data_file" }[0]).to eql(base_response)
   end
 
   it "gets an individual data file" do

--- a/spec/jekyll-admin/urlable_spec.rb
+++ b/spec/jekyll-admin/urlable_spec.rb
@@ -89,7 +89,7 @@ describe JekyllAdmin::URLable do
   end
 
   context "data files" do
-    subject { JekyllAdmin::DataFile.all[1] }
+    subject { JekyllAdmin::DataFile.all.select { |file| file.id === "data_file.yml" }[0] }
     let(:http_url) { nil }
     let(:api_url) { "#{url_base}/#{prefix}/data/data_file.yml" }
 

--- a/src/components/form/InputPath.js
+++ b/src/components/form/InputPath.js
@@ -6,6 +6,13 @@ import moment from 'moment';
 export default class InputFilename extends Component {
   handleChange = e => {
     const { onChange } = this.props;
+
+    // The `TextareaAutosize` has a `value` attribute
+    // which is supposed to be set to its inner `TextArea`'s value
+    // but is always undefined
+    // So this is a workaround
+    this.refs.input.value = e.target.value;
+
     onChange(e.target.value);
   };
 

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -113,7 +113,8 @@ export class DataFileEdit extends Component {
         data = null;
         mode = 'gui';
       } else {
-        name = this.refs.inputpath.refs.input.value;
+        name = this.refs.inputpath.refs.input.value ||
+          this.refs.inputpath.refs.input.props.defaultValue;
         data = this.refs.editor.getValue();
         mode = 'editor';
       }


### PR DESCRIPTION
Following the bug report #482 

As I understand it, the problems comes from the `TextareaAutosize` component which has a `value` attribute which is supposed to be set to its inner `TextArea`'s value but is always undefined. So I had to add the line `this.refs.input.value = e.target.value;` in the change event (workaround)

Also before the value of the `TextareaAutosize` component has been change, the `value` attribute is still undefined since the workaround has not been triggered so I added the `name = this.refs.inputpath.refs.input.value || this.refs.inputpath.refs.input.props.defaultValue;`

Now it is working for me