### PR TITLE
Use `rubocop-jekyll` to enforce Jekyll's styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site/
+.gems/
 .sass-cache/
 .jekyll-metadata
 /.bundle/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,12 @@
+require: 'rubocop-jekyll'
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: '.rubocop.yml'
 
 AllCops:
   Exclude:
     - lib/jekyll-admin/public/**/*
     - src/**/*
     - node_modules/**/*
-    - Gemfile
-    - jekyll-admin.gemspec
 
 Metrics/BlockLength:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
-rvm: 2.2
+rvm: 2.4
 before_install:
   - nvm install 6
+  - gem update --system --no-document
 install: script/bootstrap
 script: script/cibuild
 cache:
@@ -9,7 +10,6 @@ cache:
   yarn: true
   directories:
     - node_modules
-sudo: false
 env:
   matrix:
     - TEST_SUITE=node

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-admin.gemspec
 gemspec
 
 # Site dependencies
-gem 'jekyll-seo-tag'
-gem 'jekyll-sitemap'
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -1,7 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-admin/version'
+require "jekyll-admin/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-admin"
@@ -9,33 +8,32 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Mert Kahyaoğlu", "GitHub Open Source"]
   spec.email         = ["mertkahyaoglu93@gmail.com", "opensource@github.com"]
 
-  spec.summary       = %q{wp-admin for Jekyll, but better}
-  spec.description   = %q{Jekyll::Admin is a drop in administrative framework for Jekyll sites.}
+  spec.summary       = "wp-admin for Jekyll, but better"
+  spec.description   = "Jekyll::Admin is a drop in administrative framework for Jekyll sites."
   spec.homepage      = "https://github.com/jekyll/jekyll-admin"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
   spec.files         = Dir.glob("lib/**/*").concat(%w(LICENSE README.md))
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", "~> 3.3"
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"
-  spec.add_dependency "addressable", "~> 2.4"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "gem-release", "~> 0.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rubocop", "~> 0.57.2"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.10.0"
   spec.add_development_dependency "sinatra-cross_origin", "~> 0.3"
-  spec.add_development_dependency "gem-release", "~> 0.7"
 end

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -2,7 +2,6 @@ module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, API-specific functionality without duplicating logic
   module APIable
-
     CONTENT_FIELDS = %w(next previous content excerpt).freeze
 
     # Returns a hash suitable for use as an API response.
@@ -48,9 +47,7 @@ module JekyllAdmin
         output["name"] = basename
       end
 
-      if is_a?(Jekyll::StaticFile)
-        output["from_theme"] = from_theme_gem?
-      end
+      output["from_theme"] = from_theme_gem? if is_a?(Jekyll::StaticFile)
 
       output
     end
@@ -89,6 +86,7 @@ module JekyllAdmin
 
     def front_matter
       return unless file_exists?
+
       @front_matter ||= if file_contents =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
                           SafeYAML.load(Regexp.last_match(1))
                         else
@@ -98,6 +96,7 @@ module JekyllAdmin
 
     def raw_content
       return unless file_exists?
+
       @raw_content ||= if file_contents =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
                          $POSTMATCH
                        else
@@ -111,6 +110,7 @@ module JekyllAdmin
 
     def file_exists?
       return @file_exists if defined? @file_exists
+
       @file_exists = File.exist?(file_path)
     end
 
@@ -153,6 +153,7 @@ module JekyllAdmin
 
     def url_fields
       return {} unless respond_to?(:http_url) && respond_to?(:api_url)
+
       {
         "http_url" => http_url,
         "api_url"  => api_url,

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -14,7 +14,7 @@ module JekyllAdmin
     #
     # id - the file ID as passed from the API. This may or may not have an extension
     def initialize(id)
-      @id ||= File.extname(id).empty? ? "#{id}.yml" : id
+      @id = File.extname(id).empty? ? "#{id}.yml" : id
     end
     alias_method :relative_path, :id
 

--- a/lib/jekyll-admin/directory.rb
+++ b/lib/jekyll-admin/directory.rb
@@ -63,6 +63,7 @@ module JekyllAdmin
       path.entries.map do |entry|
         next if [".", ".."].include? entry.to_s
         next unless path.join(entry).directory?
+
         self.class.new(
           path.join(entry),
           :base => base, :content_type => content_type, :splat => splat

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -1,6 +1,5 @@
 module JekyllAdmin
   module FileHelper
-
     # The file the user requested in the URL
     def requested_file
       find_by_path(path)

--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -45,6 +45,7 @@ module JekyllAdmin
     # Is this request renaming a file?
     def renamed?
       return false unless request_payload["path"]
+
       ensure_leading_slash(request_payload["path"]) != relative_path
     end
 
@@ -68,6 +69,7 @@ module JekyllAdmin
 
     def ensure_leading_slash(input)
       return input if input.nil? || input.empty? || input.start_with?("/")
+
       "/#{input}"
     end
 

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -16,7 +16,7 @@ module JekyllAdmin
       register Sinatra::CrossOrigin
       enable  :cross_origin
       disable :allow_credentials
-      set :allow_methods, %i[delete get options post put]
+      set :allow_methods, [:delete, :get, :options, :post, :put]
     end
 
     get "/" do
@@ -67,9 +67,7 @@ module JekyllAdmin
       body << "\n---\n\n"
       body << request_payload["raw_content"].to_s
     end
-    alias page_body document_body
-
-    private
+    alias_method :page_body, :document_body
 
     def request_body
       @request_body ||= begin

--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -2,10 +2,10 @@ module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/configuration" do
       get do
-        json({
+        json(
           :content     => parsed_configuration,
-          :raw_content => raw_configuration,
-        })
+          :raw_content => raw_configuration
+        )
       end
 
       put do

--- a/lib/jekyll-admin/server/draft.rb
+++ b/lib/jekyll-admin/server/draft.rb
@@ -37,9 +37,7 @@ module JekyllAdmin
       # file but reside in a separate directory, `<source_dir>/_drafts/`
       def drafts
         posts = site.collections.find { |l, _c| l == "posts" }
-        if posts
-          posts[1].docs.find_all { |d| d.output_ext == ".html" && d.draft? }
-        end
+        posts[1].docs.find_all { |d| d.output_ext == ".html" && d.draft? } if posts
       end
 
       # return drafts at the same level as directory
@@ -71,6 +69,7 @@ module JekyllAdmin
 
       def ensure_html_content
         return if html_content?
+
         content_type :json
         halt 422, json("error_message" => "Invalid file extension for drafts")
       end

--- a/lib/jekyll-admin/server/page.rb
+++ b/lib/jekyll-admin/server/page.rb
@@ -36,6 +36,7 @@ module JekyllAdmin
 
       def ensure_html_content
         return if html_content?
+
         content_type :json
         halt 422, json("error_message" => "Invalid file extension for pages")
       end

--- a/lib/jekyll-admin/urlable.rb
+++ b/lib/jekyll-admin/urlable.rb
@@ -2,11 +2,11 @@ module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, URL-specific functionality without duplicating logic
   module URLable
-
     # Absolute URL to the HTTP(S) rendered/served representation of this resource
     def http_url
       return if is_a?(Jekyll::Collection) || is_a?(JekyllAdmin::DataFile)
       return if is_a?(Jekyll::Document) && !collection.write?
+
       @http_url ||= Addressable::URI.new(
         :scheme => scheme, :host => host, :port => port,
         :path => path_with_base(JekyllAdmin.site.config["baseurl"], url)
@@ -23,6 +23,7 @@ module JekyllAdmin
 
     def entries_url
       return unless is_a?(Jekyll::Collection)
+
       "#{api_url}/entries"
     end
 
@@ -30,6 +31,8 @@ module JekyllAdmin
 
     # URL path relative to `_api/` to retreive the given resource via the API
     # Note: we can't use a case statement here, because === doesn't like includes
+    #
+    # rubocop:disable Metrics/CyclomaticComplexity
     def resource_path
       if is_a?(Jekyll::Document) && draft?
         "/#{relative_path.sub(%r!\A_!, "")}"
@@ -45,6 +48,7 @@ module JekyllAdmin
         "/pages/#{relative_path}"
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # URI.join doesn't like joining two relative paths, and File.join may join
     # with `\` rather than with `/` on windows

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -3,9 +3,7 @@ module Jekyll
     class Serve < Command
       class << self
         def start_up_webrick(opts, destination)
-          if opts["livereload"]
-            @reload_reactor.start(opts)
-          end
+          @reload_reactor.start(opts) if opts["livereload"]
 
           server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
           server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)

--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -1,5 +1,5 @@
 describe JekyllAdmin::APIable do
-  %i[page post].each do |type|
+  [:page, :post].each do |type|
     context type do
       subject do
         documents = Jekyll.sites.first.send("#{type}s".to_sym)

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -31,19 +31,19 @@ describe JekyllAdmin::DataFile do
   end
 
   it "returns the hash" do
-    expect(subject.to_api).to eql({
+    expect(subject.to_api).to eql(
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
       "ext"           => ".yml",
       "title"         => "Data File",
       "api_url"       => "http://localhost:4000/_api/data/data_file.yml",
-      "http_url"      => nil,
-    })
+      "http_url"      => nil
+    )
   end
 
   it "returns the hash with content" do
-    expect(subject.to_api(:include_content => true)).to eql({
+    expect(subject.to_api(:include_content => true)).to eql(
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
@@ -54,7 +54,7 @@ describe JekyllAdmin::DataFile do
         "foo" => "bar",
       },
       "api_url"       => "http://localhost:4000/_api/data/data_file.yml",
-      "http_url"      => nil,
-    })
+      "http_url"      => nil
+    )
   end
 end

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -14,12 +14,12 @@ describe "data" do
   end
 
   let(:response_with_content) do
-    base_response.merge({
+    base_response.merge(
       "raw_content" => "foo: bar\n",
       "content"     => {
         "foo" => "bar",
-      },
-    })
+      }
+    )
   end
 
   def app
@@ -29,7 +29,7 @@ describe "data" do
   it "gets the index" do
     get "/data"
     expect(last_response).to be_ok
-    expect(last_response_parsed.select { |file| file["slug"] === "data_file" }[0]).to eql(base_response)
+    expect(last_response_parsed.find { |file| file["slug"] == "data_file" }).to eql(base_response)
   end
 
   it "gets an individual data file" do

--- a/spec/jekyll-admin/server_spec.rb
+++ b/spec/jekyll-admin/server_spec.rb
@@ -21,6 +21,7 @@ describe JekyllAdmin::Server do
     expect(last_response_parsed["foo"]).to eq("bar")
   end
 
+  # rubocop:disable Style/BracesAroundHashParameters
   it "responds to CORS preflight checks" do
     options "/", {}, { "HTTP_ORIGIN" => "http://localhost:3000" }
     expect(last_response.status).to eql(204)
@@ -34,4 +35,5 @@ describe JekyllAdmin::Server do
       expect(last_response.headers[key]).to eql(value)
     end
   end
+  # rubocop:enable Style/BracesAroundHashParameters
 end

--- a/spec/jekyll-admin/urlable_spec.rb
+++ b/spec/jekyll-admin/urlable_spec.rb
@@ -89,7 +89,7 @@ describe JekyllAdmin::URLable do
   end
 
   context "data files" do
-    subject { JekyllAdmin::DataFile.all.select { |file| file.id === "data_file.yml" }[0] }
+    subject { JekyllAdmin::DataFile.all.find { |file| file.id == "data_file.yml" } }
     let(:http_url) { nil }
     let(:api_url) { "#{url_base}/#{prefix}/data/data_file.yml" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ end
 
 def with_index_stubbed
   return yield if File.exist?(index_path)
+
   stub_index
   yield
   FileUtils.rm_f(index_path)


### PR DESCRIPTION
To stop inheriting `rubocop.yml` from the *latest* version of Jekyll as that may cause false CI failures for PRs in this project.

Miscellaneous developmental changes include:
- adding support for Bundler 2.0
- dropping test coverage for EOL Ruby 2.3 and older. 