### PR TITLE
Update Jekyll server monkey-patch to mirror Core

### DIFF
--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -2,22 +2,24 @@ module Jekyll
   module Commands
     class Serve < Command
       class << self
+        private
+
         def start_up_webrick(opts, destination)
           @reload_reactor.start(opts) if opts["livereload"]
 
-          server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
-          server.mount(opts["baseurl"], Servlet, destination, file_handler_opts)
+          @server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
+          @server.mount(opts["baseurl"].to_s, Servlet, destination, file_handler_opts)
 
-          jekyll_admin_monkey_patch(server)
+          jekyll_admin_monkey_patch
 
-          Jekyll.logger.info "Server address:", server_address(server, opts)
-          launch_browser server, opts if opts["open_url"]
-          boot_or_detach server, opts
+          Jekyll.logger.info "Server address:", server_address(@server, opts)
+          launch_browser @server, opts if opts["open_url"]
+          boot_or_detach @server, opts
         end
 
-        def jekyll_admin_monkey_patch(server)
-          server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
-          server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
+        def jekyll_admin_monkey_patch
+          @server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
+          @server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
           Jekyll.logger.info "JekyllAdmin mode:", ENV["RACK_ENV"] || "production"
         end
       end


### PR DESCRIPTION
## Summary

* Mark the methods as `private` since #start_up_webrick is a private method in the upstream command class
* From Jekyll 3.7 onward, local variable `server` is an instance_variable in the overridden method upstream

## Reference

The upstream method definition as of `v4.0.0`:
```ruby
    def start_up_webrick(opts, destination)
      @reload_reactor.start(opts) if opts["livereload"]

      @server = WEBrick::HTTPServer.new(webrick_opts(opts)).tap { |o| o.unmount("") }
      @server.mount(opts["baseurl"].to_s, Servlet, destination, file_handler_opts)

      Jekyll.logger.info "Server address:", server_address(@server, opts)
      launch_browser @server, opts if opts["open_url"]
      boot_or_detach @server, opts
    end
```