### PR TITLE
Collapse collection items in Sidebar

### DIFF
--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -62,7 +62,7 @@ export class Sidebar extends Component {
 
     return (
       <div>
-        {collectionItems.length > 0 && (
+        {collectionItems.length && (
           <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
             <a onClick={this.handleClick}>
               <i className="fa fa-book" />

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -36,7 +36,7 @@ export class Sidebar extends Component {
     }
 
     const collectionItems = _.map(collections, (col, i) => {
-      if (_.indexOf(hiddens, col.label) == -1 && col.label != 'posts') {
+      if (col.label != 'posts' && !hiddens.includes(col.label)) {
         return (
           <li key={i}>
             <Link
@@ -75,7 +75,7 @@ export class Sidebar extends Component {
             <ul>{collectionItems}</ul>
           </li>
         )}
-        {_.indexOf(hiddens, 'posts') == -1 && (
+        {!hiddens.includes('posts') && (
           <li>
             <Link
               activeClassName="active"

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -62,7 +62,7 @@ export class Sidebar extends Component {
 
     return (
       <div>
-        {collectionItems.length && (
+        {collectionItems.length > 0 && (
           <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
             <a onClick={this.handleClick}>
               <i className="fa fa-book" />

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -51,6 +51,10 @@ export class Sidebar extends Component {
       }
     }).filter(Boolean);
 
+    if (!collectionItems.length) {
+      return null;
+    }
+
     const { collapsedPanel } = this.state;
     const accordionClasses = classnames('accordion-label', {
       collapsed: collapsedPanel,
@@ -61,32 +65,17 @@ export class Sidebar extends Component {
     const panelHeight = collapsedPanel ? 50 : (collectionItems.length + 1) * 50;
 
     return (
-      <div>
-        {collectionItems.length > 0 && (
-          <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
-            <a onClick={this.handleClick}>
-              <i className="fa fa-book" />
-              {SidebarTranslations.collections}
-              <div className="counter">{collectionItems.length}</div>
-              <div className="chevrons">
-                <i className="fa fa-chevron-up" />
-              </div>
-            </a>
-            <ul>{collectionItems}</ul>
-          </li>
-        )}
-        {!hiddens.includes('posts') && (
-          <li>
-            <Link
-              activeClassName="active"
-              to={`${ADMIN_PREFIX}/collections/posts`}
-            >
-              <i className="fa fa-book" />
-              Posts
-            </Link>
-          </li>
-        )}
-      </div>
+      <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
+        <a onClick={this.handleClick}>
+          <i className="fa fa-book" />
+          {SidebarTranslations.collections}
+          <div className="counter">{collectionItems.length}</div>
+          <div className="chevrons">
+            <i className="fa fa-chevron-up" />
+          </div>
+        </a>
+        <ul>{collectionItems}</ul>
+      </li>
     );
   }
 
@@ -154,6 +143,17 @@ export class Sidebar extends Component {
         <Link className="logo" to={`${ADMIN_PREFIX}/pages`} />
         <ul className="routes">
           {collectionsPanel}
+          {postsPanel && (
+            <li>
+              <Link
+                activeClassName="active"
+                to={`${ADMIN_PREFIX}/collections/posts`}
+              >
+                <i className="fa fa-book" />
+                {SidebarTranslations.posts}
+              </Link>
+            </li>
+          )}
           {draftsPanel && (
             <li>
               <Link activeClassName="active" to={`${ADMIN_PREFIX}/drafts`}>

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -31,7 +31,7 @@ export class Sidebar extends Component {
   renderCollections(hiddens = []) {
     const { collections } = this.props;
 
-    if (collections.length === 1 && collections[0].label === 'posts') {
+    if (!collections.length) {
       return null;
     }
 
@@ -51,14 +51,14 @@ export class Sidebar extends Component {
       }
     }).filter(Boolean);
 
-    const accordionClasses = classnames({
-      'accordion-label': true,
-      collapsed: this.state.collapsedPanel,
+    const { collapsedPanel } = this.state;
+    const accordionClasses = classnames('accordion-label', {
+      collapsed: collapsedPanel,
     });
 
     // Arbitrary manipulation based on visual cues from surrounding elements.
     // TODO: Compute values programmatically.
-    const panelHeight = this.state.collapsedPanel ? 50 : (collectionItems.length + 1) * 50;
+    const panelHeight = collapsedPanel ? 50 : (collectionItems.length + 1) * 50;
 
     return (
       <div>
@@ -122,8 +122,7 @@ export class Sidebar extends Component {
     let hiddenLinks;
 
     try {
-      hiddenLinks = config.jekyll_admin.hidden_links;
-      hiddenLinks = hiddenLinks || [];
+      hiddenLinks = config.jekyll_admin.hidden_links || [];
     } catch (e) {
       hiddenLinks = [];
     }

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -14,8 +14,6 @@ import _ from 'underscore';
 export class Sidebar extends Component {
   constructor(props) {
     super(props);
-
-    this.handleClick = this.handleClick.bind(this);
     this.state = { collapsedPanel: true };
   }
 
@@ -24,11 +22,11 @@ export class Sidebar extends Component {
     fetchCollections();
   }
 
-  handleClick() {
+  handleClick = () => {
     this.setState({
       collapsedPanel: !this.state.collapsedPanel,
     });
-  }
+  };
 
   renderCollections(hiddens = []) {
     const { collections } = this.props;

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -68,7 +68,7 @@ export class Sidebar extends Component {
           <li className={accordionClasses} style={{ maxHeight: panelHeight }}>
             <a onClick={this.handleClick}>
               <i className="fa fa-book" />
-              Collections
+              {SidebarTranslations.collections}
               <div className="counter">{collectionItems.length}</div>
               <div className="chevrons">
                 <i className="fa fa-chevron-up" />

--- a/src/containers/tests/__snapshots__/sidebar.spec.js.snap
+++ b/src/containers/tests/__snapshots__/sidebar.spec.js.snap
@@ -12,50 +12,48 @@ exports[`Containers::Sidebar does not render hidden links 1`] = `
   <ul
     className="routes"
   >
-    <div>
-      <li
-        className="accordion-label collapsed"
-        style={
-          Object {
-            "maxHeight": 50,
-          }
+    <li
+      className="accordion-label collapsed"
+      style={
+        Object {
+          "maxHeight": 50,
         }
+      }
+    >
+      <a
+        onClick={[Function]}
       >
-        <a
-          onClick={[Function]}
+        <i
+          className="fa fa-book"
+        />
+        Collections
+        <div
+          className="counter"
+        >
+          1
+        </div>
+        <div
+          className="chevrons"
         >
           <i
-            className="fa fa-book"
+            className="fa fa-chevron-up"
           />
-          Collections
-          <div
-            className="counter"
-          >
-            1
-          </div>
-          <div
-            className="chevrons"
+        </div>
+      </a>
+      <ul>
+        <li>
+          <a
+            onClick={[Function]}
+            style={Object {}}
           >
             <i
-              className="fa fa-chevron-up"
+              className="fa fa-book"
             />
-          </div>
-        </a>
-        <ul>
-          <li>
-            <a
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <i
-                className="fa fa-book"
-              />
-              Movies
-            </a>
-          </li>
-        </ul>
-      </li>
-    </div>
+            Movies
+          </a>
+        </li>
+      </ul>
+    </li>
     <div
       className="splitter"
     />
@@ -114,61 +112,59 @@ exports[`Containers::Sidebar renders correctly 1`] = `
   <ul
     className="routes"
   >
-    <div>
-      <li
-        className="accordion-label collapsed"
-        style={
-          Object {
-            "maxHeight": 50,
-          }
+    <li
+      className="accordion-label collapsed"
+      style={
+        Object {
+          "maxHeight": 50,
         }
+      }
+    >
+      <a
+        onClick={[Function]}
       >
-        <a
-          onClick={[Function]}
+        <i
+          className="fa fa-book"
+        />
+        Collections
+        <div
+          className="counter"
+        >
+          1
+        </div>
+        <div
+          className="chevrons"
         >
           <i
-            className="fa fa-book"
+            className="fa fa-chevron-up"
           />
-          Collections
-          <div
-            className="counter"
-          >
-            1
-          </div>
-          <div
-            className="chevrons"
+        </div>
+      </a>
+      <ul>
+        <li>
+          <a
+            onClick={[Function]}
+            style={Object {}}
           >
             <i
-              className="fa fa-chevron-up"
+              className="fa fa-book"
             />
-          </div>
-        </a>
-        <ul>
-          <li>
-            <a
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <i
-                className="fa fa-book"
-              />
-              Movies
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li>
-        <a
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <i
-            className="fa fa-book"
-          />
-          Posts
-        </a>
-      </li>
-    </div>
+            Movies
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-book"
+        />
+        Posts
+      </a>
+    </li>
     <div
       className="splitter"
     />
@@ -238,6 +234,17 @@ exports[`Containers::Sidebar renders with zero collections 1`] = `
   <ul
     className="routes"
   >
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-book"
+        />
+        Posts
+      </a>
+    </li>
     <div
       className="splitter"
     />

--- a/src/containers/tests/__snapshots__/sidebar.spec.js.snap
+++ b/src/containers/tests/__snapshots__/sidebar.spec.js.snap
@@ -238,19 +238,6 @@ exports[`Containers::Sidebar renders with zero collections 1`] = `
   <ul
     className="routes"
   >
-    <div>
-      <li>
-        <a
-          onClick={[Function]}
-          style={Object {}}
-        >
-          <i
-            className="fa fa-book"
-          />
-          Posts
-        </a>
-      </li>
-    </div>
     <div
       className="splitter"
     />

--- a/src/containers/tests/__snapshots__/sidebar.spec.js.snap
+++ b/src/containers/tests/__snapshots__/sidebar.spec.js.snap
@@ -12,17 +12,53 @@ exports[`Containers::Sidebar does not render hidden links 1`] = `
   <ul
     className="routes"
   >
-    <li>
-      <a
-        onClick={[Function]}
-        style={Object {}}
+    <div>
+      <li
+        className="accordion-label collapsed"
+        style={
+          Object {
+            "maxHeight": 50,
+          }
+        }
       >
-        <i
-          className="fa fa-book"
-        />
-        Movies
-      </a>
-    </li>
+        <a
+          onClick={[Function]}
+        >
+          <i
+            className="fa fa-book"
+          />
+          Collections
+          <div
+            className="counter"
+          >
+            1
+          </div>
+          <div
+            className="chevrons"
+          >
+            <i
+              className="fa fa-chevron-up"
+            />
+          </div>
+        </a>
+        <ul>
+          <li>
+            <a
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <i
+                className="fa fa-book"
+              />
+              Movies
+            </a>
+          </li>
+        </ul>
+      </li>
+    </div>
+    <div
+      className="splitter"
+    />
     <div
       className="splitter"
     />
@@ -78,28 +114,64 @@ exports[`Containers::Sidebar renders correctly 1`] = `
   <ul
     className="routes"
   >
-    <li>
-      <a
-        onClick={[Function]}
-        style={Object {}}
+    <div>
+      <li
+        className="accordion-label collapsed"
+        style={
+          Object {
+            "maxHeight": 50,
+          }
+        }
       >
-        <i
-          className="fa fa-book"
-        />
-        Posts
-      </a>
-    </li>
-    <li>
-      <a
-        onClick={[Function]}
-        style={Object {}}
-      >
-        <i
-          className="fa fa-book"
-        />
-        Movies
-      </a>
-    </li>
+        <a
+          onClick={[Function]}
+        >
+          <i
+            className="fa fa-book"
+          />
+          Collections
+          <div
+            className="counter"
+          >
+            1
+          </div>
+          <div
+            className="chevrons"
+          >
+            <i
+              className="fa fa-chevron-up"
+            />
+          </div>
+        </a>
+        <ul>
+          <li>
+            <a
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <i
+                className="fa fa-book"
+              />
+              Movies
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <i
+            className="fa fa-book"
+          />
+          Posts
+        </a>
+      </li>
+    </div>
+    <div
+      className="splitter"
+    />
     <li>
       <a
         onClick={[Function]}
@@ -166,6 +238,22 @@ exports[`Containers::Sidebar renders with zero collections 1`] = `
   <ul
     className="routes"
   >
+    <div>
+      <li>
+        <a
+          onClick={[Function]}
+          style={Object {}}
+        >
+          <i
+            className="fa fa-book"
+          />
+          Posts
+        </a>
+      </li>
+    </div>
+    <div
+      className="splitter"
+    />
     <li>
       <a
         onClick={[Function]}

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -28,6 +28,18 @@ describe('Containers::Sidebar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders an accordion for collections other than posts and drafts', () => {
+    const container = mount(<Sidebar {...defaultProps} {...actions} />);
+    const accordion = container.find('ul li.accordion-label');
+    const trigger = accordion.find('a').first();
+
+    expect(accordion.prop('className')).toMatch('collapsed');
+    expect(trigger.text()).toMatch('Collections');
+
+    trigger.simulate('click');
+    expect(accordion.prop('className')).not.toMatch('collapsed');
+  });
+
   it('does not render hidden links', () => {
     const props = {
       ...defaultProps,

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -22,20 +22,64 @@
     padding: 10px 0;
     list-style: none;
     li {
+      overflow-y: hidden;
+      @include transition(max-height 0.5s);
       a {
         display: block;
         padding: 15px 20px;
         font-size: 17px;
         color: #ebdac1;
-        &.active {
+        &:hover, &.active {
           color: $dark-orange;
         }
       }
       &:hover {
         background-color: #3d3d3d;
+      }
+      &.accordion-label {
+        position: relative;
+        .counter {
+          position: absolute;
+          top: 16px;
+          right: 20px;
+          opacity: 0;
+          width: 30px;
+          padding: 3px;
+          font-size: 12px;
+          font-weight: bold;
+          text-align: center;
+          color: #333;
+          background: #ebdac1;
+          @include border-radius(10px);
+        }
+        .chevrons {
+          position: absolute;
+          top: 14px;
+          right: 20px;
+          @include transition(opacity 1s);
+          i { margin: 0; }
+        }
 
-        a {
-          color: #ffa114;
+        &.collapsed {
+          .counter {
+            opacity: 1;
+            @include transition(opacity 1s 0.25s);
+          }
+          .chevrons {
+            opacity: 0;
+          }
+        }
+        ul {
+          padding: 0;
+          list-style: none;
+
+          li {
+            background: #282828;
+            border-top: 1px solid #333;
+            border-bottom: 1px solid #181818;
+
+            a { padding-left: 40px; }
+          }
         }
       }
     }

--- a/src/translations/da.js
+++ b/src/translations/da.js
@@ -45,6 +45,7 @@ export const sidebar = {
   pages: 'Sider',
   posts: 'Indlæg',
   datafiles: 'Data filer',
+  collections: 'Samlinger',
   staticfiles: 'Statiske filer',
   configuration: 'Konfiguration',
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -46,6 +46,7 @@ export const sidebar = {
   posts: 'Posts',
   drafts: 'Drafts',
   datafiles: 'Data Files',
+  collections: 'Collections',
   staticfiles: 'Static Files',
   configuration: 'Configuration',
 };

--- a/src/translations/es.js
+++ b/src/translations/es.js
@@ -48,6 +48,7 @@ export const sidebar = {
   pages: 'Páginas',
   posts: 'Artículos',
   datafiles: 'Archivos de Datos',
+  collections: 'Colecciones',
   staticfiles: 'Archivos Estáticos',
   configuration: 'Configuración',
 };

--- a/src/translations/fr.js
+++ b/src/translations/fr.js
@@ -47,6 +47,7 @@ export const sidebar = {
   pages: 'Pages',
   posts: 'Articles',
   datafiles: 'Fichiers de données',
+  collections: 'Collections',
   staticfiles: 'Fichiers statiques',
   configuration: 'Configuration',
 };

--- a/src/translations/ptBr.js
+++ b/src/translations/ptBr.js
@@ -46,6 +46,7 @@ export const sidebar = {
   posts: 'Postagens',
   drafts: 'Rascunhos',
   datafiles: 'Arquivos de dados',
+  collections: 'Colecções',
   staticfiles: 'Arquivos estáticos',
   configuration: 'Configuração',
 };

--- a/src/translations/sv.js
+++ b/src/translations/sv.js
@@ -45,6 +45,7 @@ export const sidebar = {
   pages: 'Sidor',
   posts: 'Inlägg',
   datafiles: 'Data filer',
+  collections: 'Samlingar',
   staticfiles: 'Statiska filer',
   configuration: 'Konfiguration',
 };


### PR DESCRIPTION
To improve UX in sites with numerous collections.
  - Renders as the first item in the Sidebar giving it ample space to expand downwards.
  - Renders a counter showing count of items within panel when collapsed.
  - Renders link to 'Posts' separately.

<table>
<tr><td>
  <img width="300" tile="collections-accordion-collapsed" src="https://user-images.githubusercontent.com/12479464/65853324-c018af00-e376-11e9-866a-4118b81e26eb.png" />
</td><td>
  <img width="300" title="collections-accordion-expanded" src="https://user-images.githubusercontent.com/12479464/65852988-9d39cb00-e375-11e9-82fa-7ea585860589.png" />
</td></tr>
</table>