### PR TITLE
Allow use in sites with custom `collections_dir`

### DIFF
--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -56,7 +56,7 @@ module JekyllAdmin
       sanitized_path(
         case namespace
         when "collections"
-          File.join(collection.relative_directory, params["splat"].first)
+          File.join(collection.directory, params["splat"].first)
         when "data"
           File.join(DataFile.data_dir, params["splat"].first)
         when "drafts"


### PR DESCRIPTION
For context, `collection.directory` will return the absolute path of the directory containing the collection's documents & files.

No additional tests necessary as `collection.directory` is defined and tested at Jekyll upstream.