### PR TITLE
Refresh styling of notification messages

### DIFF
--- a/src/containers/Notifications.js
+++ b/src/containers/Notifications.js
@@ -20,7 +20,59 @@ export class Notifications extends Component {
   }
 
   render() {
-    return <NotificationSystem ref="notificationSystem" />;
+    const style = {
+      Containers: {
+        DefaultStyle: {
+          padding: 15,
+          width: 360,
+          textAlign: 'center',
+        },
+      },
+      Title: {
+        DefaultStyle: {
+          fontSize: 21,
+          color: '#fff',
+        },
+      },
+      NotificationItem: {
+        DefaultStyle: {
+          margin: 0,
+          padding: '9px 15px 15px',
+          fontSize: 15,
+          borderRadius: 0,
+          transition: '0.5s ease-in-out',
+        },
+        success: {
+          color: '#fff',
+          backgroundColor: '#5ea400',
+        },
+        error: {
+          color: '#fff',
+          backgroundColor: '#ec3d3d',
+        },
+        warning: {
+          color: '#fff',
+          backgroundColor: '#ebad1a',
+        },
+        info: {
+          color: '#fff',
+          backgroundColor: '#369cc7',
+        },
+      },
+      Dismiss: {
+        DefaultStyle: {
+          top: 7,
+          right: 9,
+          width: 25,
+          height: 25,
+          padding: 4,
+          backgroundColor: 'transparent',
+          border: '2px solid',
+          opacity: '0.84',
+        },
+      },
+    };
+    return <NotificationSystem ref="notificationSystem" style={style} />;
   }
 }
 

--- a/src/containers/Notifications.js
+++ b/src/containers/Notifications.js
@@ -19,60 +19,63 @@ export class Notifications extends Component {
     });
   }
 
+  elementStyles = {
+    Containers: {
+      DefaultStyle: {
+        padding: 15,
+        width: 360,
+        textAlign: 'center',
+      },
+    },
+    Title: {
+      DefaultStyle: {
+        fontSize: 21,
+        color: '#fff',
+      },
+    },
+    NotificationItem: {
+      DefaultStyle: {
+        margin: 0,
+        padding: '9px 15px 15px',
+        fontSize: 15,
+        borderRadius: 0,
+        transition: '0.5s ease-in-out',
+      },
+      success: {
+        color: '#fff',
+        backgroundColor: '#088217',
+      },
+      error: {
+        color: '#fff',
+        backgroundColor: '#e21414',
+      },
+      warning: {
+        color: '#fff',
+        backgroundColor: '#ebad1a',
+      },
+      info: {
+        color: '#fff',
+        backgroundColor: '#369cc7',
+      },
+    },
+    Dismiss: {
+      DefaultStyle: {
+        top: 7,
+        right: 9,
+        width: 25,
+        height: 25,
+        padding: 4,
+        backgroundColor: 'transparent',
+        border: '2px solid',
+        opacity: '0.84',
+      },
+    },
+  };
+
   render() {
-    const style = {
-      Containers: {
-        DefaultStyle: {
-          padding: 15,
-          width: 360,
-          textAlign: 'center',
-        },
-      },
-      Title: {
-        DefaultStyle: {
-          fontSize: 21,
-          color: '#fff',
-        },
-      },
-      NotificationItem: {
-        DefaultStyle: {
-          margin: 0,
-          padding: '9px 15px 15px',
-          fontSize: 15,
-          borderRadius: 0,
-          transition: '0.5s ease-in-out',
-        },
-        success: {
-          color: '#fff',
-          backgroundColor: '#5ea400',
-        },
-        error: {
-          color: '#fff',
-          backgroundColor: '#ec3d3d',
-        },
-        warning: {
-          color: '#fff',
-          backgroundColor: '#ebad1a',
-        },
-        info: {
-          color: '#fff',
-          backgroundColor: '#369cc7',
-        },
-      },
-      Dismiss: {
-        DefaultStyle: {
-          top: 7,
-          right: 9,
-          width: 25,
-          height: 25,
-          padding: 4,
-          backgroundColor: 'transparent',
-          border: '2px solid',
-          opacity: '0.84',
-        },
-      },
-    };
-    return <NotificationSystem ref="notificationSystem" style={style} />;
+    return (
+      <NotificationSystem ref="notificationSystem" style={this.elementStyles} />
+    );
   }
 }
 


### PR DESCRIPTION
Just visual changes to remove the outdated look from the notification messages..

A sample of notifications for the various levels:

key | sample
:---: | ---
**`'info'`** | ![info-notif](https://user-images.githubusercontent.com/12479464/66196545-5cfc8480-e6b6-11e9-8e06-063aed4ecd48.png)
**`'success'`** | ![success-notif](https://user-images.githubusercontent.com/12479464/66196369-02fbbf00-e6b6-11e9-9121-28af9d13d566.png)
**`'warning'`** | ![warning-notif](https://user-images.githubusercontent.com/12479464/66196599-70a7eb00-e6b6-11e9-809f-c64f0caa63ae.png)
**`'error'`** | ![error-notif](https://user-images.githubusercontent.com/12479464/66196437-258dd800-e6b6-11e9-85ae-e350be62fa05.png)
