### PR TITLE
Refresh aesthetics of admin interface

### DIFF
--- a/src/styles/breadcrumbs.scss
+++ b/src/styles/breadcrumbs.scss
@@ -1,10 +1,9 @@
 .breadcrumbs {
-  margin: 0 30px 10px 0;
-  list-style: none;
+  margin: 0 30px 0 0;
   padding: 0;
+  list-style: none;
   li {
     float: left;
-    position: relative;
     &:not(:last-child):after {
       content: "/";
       padding: 0 8px;

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -8,7 +8,7 @@
   padding: 12px 20px;
   white-space: nowrap;
   text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.2);
-  @include border-radius($border-radius);
+  @include border-radius(4px);
   @include box-sizing(border-box);
   @include btn($btn-initial, $btn-initial-border);
   i {
@@ -24,7 +24,7 @@
 
 .btn-thin {
   padding: 8px;
-  margin: 5px;
+  margin: 0 5px;
 }
 
 .btn-active {

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -8,8 +8,7 @@
   padding: 12px 20px;
   white-space: nowrap;
   text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.2);
-  @include border-radius(4px);
-  @include box-sizing(border-box);
+  border-radius: 4px;
   @include btn($btn-initial, $btn-initial-border);
   i {
     margin-right: 4px;
@@ -39,7 +38,7 @@
   @include btn($btn-success, $btn-success-border, pointer);
   &:hover {
     background-color: lighten($btn-success, 5%) !important;
-    @include box-shadow(0 1px 0 $btn-success-border);
+    box-shadow: 0 1px 0 $btn-success-border;
   }
 }
 

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -6,7 +6,7 @@
     background-color: #f2f2f2;
     margin: 0.5em 0;
     border: 1px solid $border-color;
-    @include border-radius($border-radius);
+    border-radius: $border-radius;
   }
 
   thead {
@@ -19,11 +19,11 @@
       position: relative;
 
       &:first-child {
-        @include border-top-left-radius($border-radius);
+        border-top-left-radius: $border-radius;
       }
 
       &:last-child {
-        @include border-top-right-radius($border-radius);
+        border-top-right-radius: $border-radius;
       }
     }
   }
@@ -126,7 +126,7 @@
       }
       .side-link {
         text-align: center;
-        @include border-radius($border-radius);
+        border-radius: $border-radius;
         margin-bottom: 10px;
         width: 100%;
         display: inline-block;
@@ -176,8 +176,8 @@
       color: $white;
       text-align: center;
       background: $dark-gray;
-      @include border-radius($border-radius);
-      @include box-shadow(0px 2px 8px 2px rgba(0, 0, 0, 0.08));
+      border-radius: $border-radius;
+      box-shadow: 0px 2px 8px 2px rgba(0, 0, 0, 0.08);
       &:after {
         content: "";
         position: absolute;

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -4,28 +4,19 @@
   table {
     width: 100%;
     background-color: #f2f2f2;
-    margin: .5em 0;
-    font-size: 18px;
+    margin: 0.5em 0;
+    border: 1px solid $border-color;
     @include border-radius($border-radius);
-    @include box-shadow(0 1px 3px rgba(0,0,0,.3));
   }
 
   thead {
-    @include border-top-left-radius($border-radius);
-    @include border-top-right-radius($border-radius);
     color: #fff;
-    background-color: #3a3a3a;
-    background-image: -webkit-gradient(linear, left top, left bottom, from(#3a3a3a), to(#1e1e1e));
-    background-image: -webkit-linear-gradient(top, #3a3a3a 0%, #1e1e1e 100%);
-    background-image: -moz-linear-gradient(top, #3a3a3a 0%, #1e1e1e 100%);
-    background-image: -o-linear-gradient(top, #3a3a3a 0%, #1e1e1e 100%);
-    background-image: linear-gradient(to bottom, #3a3a3a 0%,#1e1e1e 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#3a3a3a', endColorstr='#1e1e1e',GradientType=0 );
+    background-color: #333;
+    border: 1px solid #333;
 
     th {
       text-align: left;
       position: relative;
-      @include box-shadow(inset 0 1px 0 rgba(255,255,255,.1));
 
       &:first-child {
         @include border-top-left-radius($border-radius);
@@ -44,9 +35,9 @@
   th {
     text-transform: uppercase;
     font-size: 16px;
-    padding: .5em .75em;
+    padding: 12px;
     text-shadow: 0 -1px 0 rgba(0,0,0,.9);
-    color: #888;
+    color: #ddd;
   }
 
   th.th-actions {
@@ -55,16 +46,10 @@
   }
 
   tbody td {
-    padding: 20px 12px;
+    height: 63px;
+    padding: 15px 0.75em;
     vertical-align: middle;
-    border-top: 1px solid rgba(0,0,0,.1);
-    @include box-shadow(inset 0 1px 0 rgba(255,255,255,.1));
-    background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(255,255,255,0.1)), to(rgba(255,255,255,0)));
-    background-image: -webkit-linear-gradient(top, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0) 100%);
-    background-image: -moz-linear-gradient(top, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0) 100%);
-    background-image: -o-linear-gradient(top, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0) 100%);
-    background-image: linear-gradient(to bottom, rgba(255,255,255,0.1) 0%,rgba(255,255,255,0) 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1affffff', endColorstr='#00ffffff',GradientType=0 );
+    border-top: 1px solid $border-color;
   }
 
   td.row-title {
@@ -79,8 +64,6 @@
 
   td .row-actions {
     float: right;
-    min-width: 96px;
-    font-size: 16px;
   }
 }
 
@@ -94,7 +77,7 @@
     h1 {
       margin: 0 40px 0 0;
       float: left;
-      text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.3);
+      text-shadow: 1px 1px 1px rgba(68, 68, 68, 0.21);
     }
     .page-buttons {
       display: flex;
@@ -175,7 +158,7 @@
 
   .splitter {
     margin: 15px 0;
-    background: #cfcfcf;
+    background: $border-color;
     border: 0;
   }
 

--- a/src/styles/datagui.scss
+++ b/src/styles/datagui.scss
@@ -2,6 +2,7 @@
   margin-bottom: 40px;
   padding: 30px;
   background: #222;
+  @include border-radius($border-radius);
   .metafield {
     position: relative;
     margin-bottom: 5px;
@@ -10,16 +11,16 @@
       color: #eb2659;
       .key-field {
         max-width: 190px;
-        min-height: 46px;
+        min-height: 42px;
         margin: 0 0 10px;
-        padding: 11px 10px;
+        padding: 8px 10px;
         font-size: 16px;
         font-weight: 700;
         line-height: 1.5;
         color: #eb2659;
         background: #2b2b2b;
         border: 1px solid transparent;
-        @include border-radius(2px);
+        @include border-radius($border-radius);
         @include transition(color 250ms ease);
         &:focus {
           color: #eaeaea !important;
@@ -41,12 +42,12 @@
     .meta-value {
       .value-field {
         width: 100%;
-        min-height: 46px;
+        min-height: 42px;
         height: auto;
         max-height: 500px;
         overflow: hidden;
         margin-bottom: 10px;
-        padding: 11px 13px;
+        padding: 8px 10px;
         font-size: 16px;
         line-height: 1.5;
         color: #eaeaea;
@@ -55,7 +56,7 @@
         resize: vertical;
         background: #2b2b2b;
         border: 1px solid transparent;
-        @include border-radius(2px);
+        @include border-radius($border-radius);
         @include transition(color 250ms ease);
         &:focus {
           border-color: $dark-orange;
@@ -75,14 +76,14 @@
           position: absolute;
           top: 0;
           right: 0;
-          height: 48px;
+          height: 42px;
           pointer-events: auto;
           button {
             display: inline-block;
-            min-width: 48px;
+            min-width: 42px;
             height: 100%;
             margin: 0;
-            padding: 0;
+            padding: 0 3px 0 0;
             color: #818181;
             line-height: 2.286em;
             text-align: center;
@@ -108,10 +109,10 @@
       margin-right: auto;
       margin-bottom: 20px;
       margin-left: 36px;
-      padding: 10px 15px;
+      padding: 8px 10px;
       pointer-events: auto;
       border: 1px solid #383838;
-      @include border-radius(2px);
+      @include border-radius($border-radius);
       .array-item-wrap {
         margin-bottom: 5px;
         .array-header {
@@ -165,12 +166,12 @@
           margin-bottom: 10px;
           input {
             width: 100%;
-            min-height: 48px;
-            padding: 11px 55px 10px 11px;
+            min-height: 42px;
+            padding: 8px 55px 8px 10px;
             font-size: 16px;
             line-height: 1.5;
             pointer-events: auto;
-            @include border-radius(2px);
+            @include border-radius($border-radius);
           }
           .meta-buttons {
             position: absolute;
@@ -223,7 +224,7 @@
     }
     .meta-buttons {
       position: absolute;
-      top: 4px;
+      top: 12px;
       right: 0;
       z-index: 8;
       span.move {
@@ -272,7 +273,7 @@
           transform: translateX(-50%);
           z-index: 30;
           border: 1px solid #323232;
-          @include border-radius(2px);
+          @include border-radius($border-radius);
           &:before {
             position: absolute;
             top: -10px;
@@ -331,7 +332,7 @@
               right: 0;
               pointer-events: auto;
               .value-field {
-                width: calc(100% - 50px);
+                width: calc(100% - 44px);
               }
             }
             >.date-field {
@@ -349,7 +350,7 @@
         right: 36px;
         width: calc(100% - 227px);
         .value-field {
-          width: calc(100% - 65px);
+          width: calc(100% - 59px);
           margin-left: 15px;
         }
       }
@@ -361,7 +362,7 @@
           right: 0;
           width: 100%;
           .value-field {
-            width: calc(100% - 50px);
+            width: calc(100% - 44px);
           }
         }
         .date-field {
@@ -378,7 +379,7 @@
           width: calc(100% - 190px);
           pointer-events: auto;
           .value-field {
-            width: calc(100% - 65px);
+            width: calc(100% - 59px);
             margin-left: 15px;
           }
         }
@@ -411,14 +412,14 @@
     pointer-events: auto;
     background: #222;
     &.rw-widget {
-      @include border-radius(2px);
+      @include border-radius($border-radius);
       border-color: transparent;
     }
     input {
       padding: 11px 13px;
       width: calc(100% - 3px);
-      min-height: 46px;
-      @include border-radius(2px);
+      min-height: 40px;
+      @include border-radius($border-radius);
       color: white;
       background: #2b2b2b;
     }

--- a/src/styles/datagui.scss
+++ b/src/styles/datagui.scss
@@ -2,7 +2,7 @@
   margin-bottom: 40px;
   padding: 30px;
   background: #222;
-  @include border-radius($border-radius);
+  border-radius: $border-radius;
   .metafield {
     position: relative;
     margin-bottom: 5px;
@@ -20,7 +20,7 @@
         color: #eb2659;
         background: #2b2b2b;
         border: 1px solid transparent;
-        @include border-radius($border-radius);
+        border-radius: $border-radius;
         @include transition(color 250ms ease);
         &:focus {
           color: #eaeaea !important;
@@ -56,7 +56,7 @@
         resize: vertical;
         background: #2b2b2b;
         border: 1px solid transparent;
-        @include border-radius($border-radius);
+        border-radius: $border-radius;
         @include transition(color 250ms ease);
         &:focus {
           border-color: $dark-orange;
@@ -112,7 +112,7 @@
       padding: 8px 10px;
       pointer-events: auto;
       border: 1px solid #383838;
-      @include border-radius($border-radius);
+      border-radius: $border-radius;
       .array-item-wrap {
         margin-bottom: 5px;
         .array-header {
@@ -147,7 +147,7 @@
         text-align: center;
         color: white;
         background: $dark-orange;
-        @include border-radius(50%);
+        border-radius: 50%;
         i {
           margin: 0;
         }
@@ -171,7 +171,7 @@
             font-size: 16px;
             line-height: 1.5;
             pointer-events: auto;
-            @include border-radius($border-radius);
+            border-radius: $border-radius;
           }
           .meta-buttons {
             position: absolute;
@@ -247,7 +247,7 @@
           text-align: center;
           outline: none;
           border: 2px solid #575757;
-          @include border-radius(50%);
+          border-radius: 50%;
           &:hover, &:focus {
             color: white;
             background: $dark-orange;
@@ -273,7 +273,7 @@
           transform: translateX(-50%);
           z-index: 30;
           border: 1px solid #323232;
-          @include border-radius($border-radius);
+          border-radius: $border-radius;
           &:before {
             position: absolute;
             top: -10px;
@@ -412,14 +412,14 @@
     pointer-events: auto;
     background: #222;
     &.rw-widget {
-      @include border-radius($border-radius);
+      border-radius: $border-radius;
       border-color: transparent;
     }
     input {
       padding: 11px 13px;
       width: calc(100% - 3px);
       min-height: 40px;
-      @include border-radius($border-radius);
+      border-radius: $border-radius;
       color: white;
       background: #2b2b2b;
     }

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -2,7 +2,7 @@
 
 .config-editor {
   border: 1px solid $border-color;
-  @include border-radius($border-radius);
+  border-radius: $border-radius;
   outline: none;
   font-size: 14px;
 }

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -7,8 +7,7 @@
   padding: .429em .857em;
   border: 1px solid lighten($border-color, 7%);
   font-size: 14px;
-  @include box-sizing(border-box);
-  @include border-radius($border-radius);
+  border-radius: $border-radius;
   &:focus {
     border-color: $border-color-focus;
   }
@@ -107,7 +106,7 @@
     bottom: 4px;
     background-color: white;
     @include transition(.4s);
-    @include border-radius(50%);
+    border-radius: 50%;
   }
 
   input:checked + .slider {
@@ -151,7 +150,7 @@
     color: white;
     background-color: #2b2b2b;
     border: 1px solid transparent;
-    @include border-radius($border-radius);
+    border-radius: $border-radius;
   }
 
   input {

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -5,10 +5,9 @@
   width: 100%;
   height: 2.286em;
   padding: .429em .857em;
-  border: 1px solid $border-color;
+  border: 1px solid lighten($border-color, 7%);
   font-size: 14px;
   @include box-sizing(border-box);
-  @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075));
   @include border-radius($border-radius);
   &:focus {
     border-color: $border-color-focus;
@@ -37,7 +36,7 @@
     background: none;
     outline: none;
     border: 0;
-    border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid $border-color;
     box-shadow: none;
     &:focus {
       color: #000 !important;
@@ -51,8 +50,8 @@
 
 .input-title {
   textarea {
-    min-height: 57px;
-    font-size: 45px;
+    min-height: 51px;
+    font-size: 42px;
   }
 }
 
@@ -131,7 +130,6 @@
     display: inline-block;
     margin: 0 4px;
     padding: 0;
-    border-radius: 5px;
     border-color: transparent;
 
     &.filename { width: 84%; }
@@ -153,7 +151,7 @@
     color: white;
     background-color: #2b2b2b;
     border: 1px solid transparent;
-    border-radius: 2px;
+    @include border-radius($border-radius);
   }
 
   input {

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -2,10 +2,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 75px;
+  height: 60px;
   background-color: white;
   padding: 0 40px;
-  @include box-shadow(0 2px 4px 0 rgba(204, 204, 204, 0.4));
+  border-bottom: 1px solid lighten($border-color, 9%);
   .title {
     font-weight: normal;
     a {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -21,7 +21,7 @@
 body {
   color: #444;
   font-family: lato, Helvetica, Helvetica Neue;
-  background-color: #f7f7f7;
+  background-color: $background-color;
 }
 
 h1,h2,h3,h4,h5 {
@@ -71,7 +71,7 @@ div:focus {
 .splitter {
   height: 1px;
   width: 100%;
-  margin: 5px 0;
+  margin: 3px 0;
   border-bottom: 1px solid #424242;
   border-top: 1px solid #212121;
 }
@@ -86,6 +86,7 @@ div:focus {
   color: #8a6e00;
   text-align: center;
   background-color: #fff5cc;
+  border: 1px solid rgba(138, 110, 0, 0.18);
 }
 
 .pull-right {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -14,7 +14,7 @@
 @import "button";
 @import "staticfiles";
 
-* {
+*, *:before, *:after {
   box-sizing: border-box;
 }
 

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -10,8 +10,8 @@
         max-width: 190px;
         font-size: 16px;
         font-weight: 700;
-        padding: 11px 10px;
-        min-height: 46px;
+        padding: 8px 10px;
+        min-height: 42px;
         line-height: 1.5;
         border: 1px solid $border-color;
         @include border-radius(2px);
@@ -32,14 +32,14 @@
         resize: vertical;
         height: auto;
         width: 100%;
-        min-height: 46px;
+        min-height: 42px;
         max-height: 500px;
         line-height: 1.5;
         margin-bottom: 0;
         vertical-align: bottom;
         border: 1px solid $border-color;
         font-size: 16px;
-        padding: 11px 13px;
+        padding: 8px 10px;
         @include border-radius(2px);
         @include transition(color 250ms ease);
         &:focus {
@@ -101,7 +101,7 @@
           margin-bottom: 5px;
           input {
             width: 100%;
-            padding: 11px 55px 10px 11px;
+            padding: 8px 55px 10px 11px;
             font-size: 16px;
             min-height: 48px;
             line-height: 1.5;
@@ -237,24 +237,25 @@
     z-index: 30;
   }
   .date-field {
+    max-height: 42px;
     @include border-radius(2px);
     border-color: $border-color;
     input {
-      padding: 11px 13px;
-      min-height: 46px;
+      padding: 8px 10px;
+      min-height: 40px;
     }
   }
   .rw-datetimepicker {
     box-shadow: none !important;
     font-size: 16px !important;
     .rw-btn {
-      min-width: 37px;
+      min-width: 42px;
       i { margin: 0; }
     }
     &.rw-has-both {
-      padding-right: 74px;
+      padding-right: 84px;
       > .rw-select {
-        width: 75px;
+        width: 85px;
         &:hover {
           background: #fff;
         }
@@ -295,7 +296,7 @@
         color: #333;
         line-height: 2.286em;
         height: 100%;
-        min-width: 37px;
+        min-width: 38px;
         display: inline-block;
         margin: 0;
         text-align: center;

--- a/src/styles/metafields.scss
+++ b/src/styles/metafields.scss
@@ -14,7 +14,7 @@
         min-height: 42px;
         line-height: 1.5;
         border: 1px solid $border-color;
-        @include border-radius(2px);
+        border-radius: 2px;
         @include transition(color 250ms ease);
         &:focus {
           border-color: $dark-orange;
@@ -40,7 +40,7 @@
         border: 1px solid $border-color;
         font-size: 16px;
         padding: 8px 10px;
-        @include border-radius(2px);
+        border-radius: 2px;
         @include transition(color 250ms ease);
         &:focus {
           border-color: $dark-orange;
@@ -50,7 +50,7 @@
     .meta-value-array {
       padding: 10px 15px;
       border: 1px solid $border-color;
-      @include border-radius(3px);
+      border-radius: 3px;
       position: relative;
       .array-item-wrap {
         margin-bottom: 20px;
@@ -105,7 +105,7 @@
             font-size: 16px;
             min-height: 48px;
             line-height: 1.5;
-            @include border-radius(2px);
+            border-radius: 2px;
           }
           .meta-buttons {
             transform: translateY(-50%);
@@ -156,7 +156,7 @@
           display: inline-block;
           text-align: center;
           outline: none;
-          @include border-radius(50%);
+          border-radius: 50%;
           &:hover, &:focus {
             border-color: $dark-orange;
             background: $dark-orange;
@@ -238,7 +238,7 @@
   }
   .date-field {
     max-height: 42px;
-    @include border-radius(2px);
+    border-radius: 2px;
     border-color: $border-color;
     input {
       padding: 8px 10px;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,32 +1,8 @@
-@mixin box-shadow($shadow...) {
-  -webkit-box-shadow: $shadow;
-     -moz-box-shadow: $shadow;
-          box-shadow: $shadow;
-}
-
-@mixin box-sizing($sizing...) {
-  -webkit-box-sizing: $sizing;
-     -moz-box-sizing: $sizing;
-          box-sizing: $sizing;
-}
-
-@mixin border-radius($radius...) {
-  -webkit-border-radius: $radius;
-     -moz-border-radius: $radius;
-          border-radius: $radius;
-}
-
-@mixin border-top-left-radius($radius...) {
-  -webkit-border-top-left-radius: $radius;
-     -moz-border-radius-topleft:  $radius;
-          border-top-left-radius: $radius;
-}
-
-@mixin border-top-right-radius($radius...) {
-  -webkit-border-top-right-radius: $radius;
-     -moz-border-radius-topright:  $radius;
-          border-top-right-radius: $radius;
-}
+@mixin box-shadow($shadow...) { box-shadow: $shadow }
+@mixin box-sizing($sizing...) { box-sizing: $sizing }
+@mixin border-radius($radius...) { border-radius: $radius }
+@mixin border-top-left-radius($radius...) { border-top-left-radius: $radius }
+@mixin border-top-right-radius($radius...) { border-top-right-radius: $radius }
 
 @mixin transition($transition...) {
   -webkit-transition: $transition;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,9 +1,3 @@
-@mixin box-shadow($shadow...) { box-shadow: $shadow }
-@mixin box-sizing($sizing...) { box-sizing: $sizing }
-@mixin border-radius($radius...) { border-radius: $radius }
-@mixin border-top-left-radius($radius...) { border-top-left-radius: $radius }
-@mixin border-top-right-radius($radius...) { border-top-right-radius: $radius }
-
 @mixin transition($transition...) {
   -webkit-transition: $transition;
      -moz-transition: $transition;
@@ -28,7 +22,7 @@
   cursor: $cursor;
   opacity: $opacity;
   background-color: $color;
-  @include box-shadow(0 1px 0 $border-color);
+  box-shadow: 0 1px 0 $border-color;
   &:hover {
     @if ($hover-fx) {
       background-color: lighten($color, 5%);

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -49,7 +49,7 @@
           text-align: center;
           color: #333;
           background: #beb9b1;
-          @include border-radius(10px);
+          border-radius: 10px;
         }
         .chevrons {
           position: absolute;

--- a/src/styles/sidebar.scss
+++ b/src/styles/sidebar.scss
@@ -9,10 +9,9 @@
   background-color: #333;
   .logo {
     display: block;
-    height: 75px;
+    height: 60px;
     background: #222222 url(../assets/images/logo.png) no-repeat center;
-    background-size: 110px 46px;
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.4);
+    background-size: 90px 40px;
     &:hover {
       -webkit-filter: brightness(1.2);
       filter: brightness(1.2);
@@ -28,7 +27,7 @@
         display: block;
         padding: 15px 20px;
         font-size: 17px;
-        color: #ebdac1;
+        color: #beb9b1;
         &:hover, &.active {
           color: $dark-orange;
         }
@@ -40,16 +39,16 @@
         position: relative;
         .counter {
           position: absolute;
-          top: 16px;
+          top: 15px;
           right: 20px;
           opacity: 0;
-          width: 30px;
+          min-width: 20px;
           padding: 3px;
           font-size: 12px;
           font-weight: bold;
           text-align: center;
           color: #333;
-          background: #ebdac1;
+          background: #beb9b1;
           @include border-radius(10px);
         }
         .chevrons {

--- a/src/styles/staticfiles.scss
+++ b/src/styles/staticfiles.scss
@@ -4,7 +4,7 @@
   color: #9098A3;
   background-color: white;
   border: 1px solid $border-color;
-  @include border-radius($border-radius);
+  border-radius: $border-radius;
   position: relative;
   .preview-info {
     padding: 40px;
@@ -33,7 +33,7 @@
     background-color: #fcfcfc;
     margin: 10px 7px;
     position: relative;
-    @include border-radius($border-radius);
+    border-radius: $border-radius;
     &:hover .delete{
       opacity: 1;
     }

--- a/src/styles/staticfiles.scss
+++ b/src/styles/staticfiles.scss
@@ -29,14 +29,15 @@
   .file-preview {
     display: flex;
     flex-direction: column;
-    border: 1px solid transparent;
+    border: 1px solid lighten($border-color, 12%);
     background-color: #fcfcfc;
-    margin: 10px;
+    margin: 10px 7px;
     position: relative;
     @include border-radius($border-radius);
     &:hover .delete{
       opacity: 1;
     }
+    a { height: 150px; }
     div {
       width: 150px;
       height: 150px;
@@ -64,6 +65,7 @@
       }
     }
     span.filename {
+      padding: 5px;
       font-size: 14px;
       line-height: 2;
       text-align: center;
@@ -71,6 +73,8 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      border-top: 1px solid lighten($border-color, 9%);
+      border-bottom: 1px solid lighten($border-color, 9%);
     }
     img {
       @include nodrag();

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -12,9 +12,11 @@ $inactive-gray: #9ea1a3;
 $new: #68BD6A;
 $new-hover: #80ce81;
 
-$border-color: #d4d7d9;
+$background-color: #f8f8f8;
+
+$border-color: darken($background-color, 15%);
 $border-color-focus: $orange;
-$border-radius: 4px;
+$border-radius: 2px;
 
 $btn-initial: #9ea1a3;
 $btn-initial-border: #828282;


### PR DESCRIPTION
  * Reduce size of container headers and table cells to allow rendering more content in the viewport.
  * Replace gradients and shadows with a modern flat aethetic.
  * Reduce rounded-corners to a more subtle presence. Buttons  remain at current 4px rounded-corners.
  * Remove irrelevant mixin statements.
  * Improve staticfile-preview aesthetics.

### Before

![jekyll-admin-master](https://user-images.githubusercontent.com/12479464/66265426-e08fb000-e833-11e9-8b14-6a4e518a5570.png)

![static-files-master](https://user-images.githubusercontent.com/12479464/66267057-543cb780-e84a-11e9-8752-86c8ba0a4193.png)

### After

![jekyll-admin-pr](https://user-images.githubusercontent.com/12479464/66267030-d9739c80-e849-11e9-8b15-a74d8b5ffb9a.png)

![static-files-pr](https://user-images.githubusercontent.com/12479464/66267070-7df5de80-e84a-11e9-887d-fd3c4a1cbf53.png)
