### PR TITLE
Allow drawing tables easily in the Markdown editor

### DIFF
--- a/src/components/MarkdownEditor.js
+++ b/src/components/MarkdownEditor.js
@@ -50,6 +50,7 @@ class MarkdownEditor extends Component {
       '|',
       'link',
       'image',
+      'table',
       '|',
       'preview',
       'side-by-side',


### PR DESCRIPTION
`SimpleMDE` has a built-in feature to allow drawing tables with a button-click.
This pull request just enables that feature.