### PR TITLE
Freeze Ruby string literals with the pragma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,9 +15,6 @@ Metrics/BlockLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Naming/MemoizedInstanceVariableName:
   Exclude:
     - lib/jekyll-admin/page_without_a_file.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify the gem's dependencies in jekyll-admin.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 task :default => :spec

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3.0"
+
   spec.add_dependency "jekyll", ">= 3.3", "< 5.0"
   spec.add_dependency "sinatra", "~> 1.4"
   spec.add_dependency "sinatra-contrib", "~> 1.4"

--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "jekyll-admin/version"

--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Default Sinatra to "production" mode (surpress errors) unless
 # otherwise specified by the `RACK_ENV` environmental variable.
 # Must be done prior to requiring Sinatra, or we'll get a LoadError

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, API-specific functionality without duplicating logic

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class DataFile
     METHODS_FOR_LIQUID = %w(path relative_path slug ext title).freeze

--- a/lib/jekyll-admin/directory.rb
+++ b/lib/jekyll-admin/directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Directory
     extend Forwardable

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   module FileHelper
     # The file the user requested in the URL

--- a/lib/jekyll-admin/page_without_a_file.rb
+++ b/lib/jekyll-admin/page_without_a_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class PageWithoutAFile < Jekyll::Page
     def read_yaml(*)

--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   module PathHelper
     def sanitized_path(path)

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     ROUTES = %w(collections configuration data drafts pages static_files).freeze
@@ -63,12 +65,13 @@ module JekyllAdmin
     end
 
     def document_body
-      body = if front_matter && !front_matter.empty?
-               YAML.dump(restored_front_matter).strip
-                 .gsub(": 'null'", ": null") # restore null values
-             else
-               "---"
-             end
+      body = String.new("")
+      body << if front_matter && !front_matter.empty?
+                YAML.dump(restored_front_matter).strip
+                  .gsub(": 'null'", ": null") # restore null values
+              else
+                "---"
+              end
       body << "\n---\n\n"
       body << request_payload["raw_content"].to_s
     end

--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -65,7 +65,7 @@ module JekyllAdmin
     end
 
     def document_body
-      body = String.new("")
+      body = +""
       body << if front_matter && !front_matter.empty?
                 YAML.dump(restored_front_matter).strip
                   .gsub(": 'null'", ": null") # restore null values

--- a/lib/jekyll-admin/server/collection.rb
+++ b/lib/jekyll-admin/server/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/collections" do

--- a/lib/jekyll-admin/server/configuration.rb
+++ b/lib/jekyll-admin/server/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/configuration" do

--- a/lib/jekyll-admin/server/data.rb
+++ b/lib/jekyll-admin/server/data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     # supported extensions, in order of preference, for now, no .csv

--- a/lib/jekyll-admin/server/draft.rb
+++ b/lib/jekyll-admin/server/draft.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/drafts" do

--- a/lib/jekyll-admin/server/page.rb
+++ b/lib/jekyll-admin/server/page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/pages" do

--- a/lib/jekyll-admin/server/static_file.rb
+++ b/lib/jekyll-admin/server/static_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class Server < Sinatra::Base
     namespace "/static_files" do

--- a/lib/jekyll-admin/static_server.rb
+++ b/lib/jekyll-admin/static_server.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   class StaticServer < Sinatra::Base
     set :public_dir, File.expand_path("./public", File.dirname(__FILE__))
 
-    MUST_BUILD_MESSAGE = "Front end not yet built. Run `script/build` to build.".freeze
+    MUST_BUILD_MESSAGE = "Front end not yet built. Run `script/build` to build."
 
     # Allow `/admin` and `/admin/`, and `/admin/*` to serve `/public/dist/index.html`
     get "/*" do

--- a/lib/jekyll-admin/urlable.rb
+++ b/lib/jekyll-admin/urlable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
   # Abstract module to be included in Convertible and Document to provide
   # additional, URL-specific functionality without duplicating logic

--- a/lib/jekyll-admin/version.rb
+++ b/lib/jekyll-admin/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module JekyllAdmin
-  VERSION = "0.9.0".freeze
+  VERSION = "0.9.0"
 end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jekyll
   module Commands
     class Serve < Command

--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin::APIable do
   [:page, :post].each do |type|
     context type do

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin::DataFile do
   let(:data_dir) { "_data" }
   let(:relative_path) { "data_file.yml" }

--- a/spec/jekyll-admin/file_helper_spec.rb
+++ b/spec/jekyll-admin/file_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FileHelperTest
   include JekyllAdmin::FileHelper
   include JekyllAdmin::PathHelper

--- a/spec/jekyll-admin/integration_spec.rb
+++ b/spec/jekyll-admin/integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "integration" do
   let(:source) { fixture_path("site") }
   let(:dest) { File.join(source, "_site") }

--- a/spec/jekyll-admin/path_helper_spec.rb
+++ b/spec/jekyll-admin/path_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PathHelperTest
   include JekyllAdmin::PathHelper
 

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "collections" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server/configuration_spec.rb
+++ b/spec/jekyll-admin/server/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "configuration" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "data" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server/draft_spec.rb
+++ b/spec/jekyll-admin/server/draft_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "drafts" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "pages" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server/static_file_spec.rb
+++ b/spec/jekyll-admin/server/static_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "static_files" do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/server_spec.rb
+++ b/spec/jekyll-admin/server_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin::Server do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/static_server_spec.rb
+++ b/spec/jekyll-admin/static_server_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin::StaticServer do
   include Rack::Test::Methods
 

--- a/spec/jekyll-admin/urlable_spec.rb
+++ b/spec/jekyll-admin/urlable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin::URLable do
   subject { JekyllAdmin.site.pages.first }
   let(:scheme) { "http" }

--- a/spec/jekyll_admin_spec.rb
+++ b/spec/jekyll_admin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe JekyllAdmin do
   include Rack::Test::Methods
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RACK_ENV"] = "test"
 
 require "rspec"


### PR DESCRIPTION
`# frozen_string_literal: true` pragma at the top of a Ruby file instructs the interpreter to consider all string literals in that file as immutable or frozen.

*Additionally adds a requirement for at least Ruby 2.3.0 to allow using the `String#+@` method to obtain an unfrozen copy of a string.*