### PR TITLE
Compute data file's extname just once

### DIFF
--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -10,15 +10,25 @@ module JekyllAdmin
     include PathHelper
     extend PathHelper
 
-    attr_reader :id
+    attr_reader :id, :ext
 
     # Initialize a new DataFile object
     #
     # id - the file ID as passed from the API. This may or may not have an extension
     def initialize(id)
-      @id = File.extname(id).empty? ? "#{id}.yml" : id
+      extname = File.extname(id)
+      if extname.empty?
+        @id  = "#{id}.yml"
+        @ext = ".yml"
+      else
+        @id  = id
+        @ext = extname
+      end
     end
     alias_method :relative_path, :id
+
+    # Returns the file's extension with preceeding `.`
+    alias_method :extension, :ext
 
     def exists?
       @exists ||= File.exist?(absolute_path)
@@ -33,16 +43,6 @@ module JekyllAdmin
     def content
       @content ||= data_reader.read_data_file(absolute_path)
     end
-
-    # Returns the file's extension with preceeding `.`
-    def ext
-      @ext ||= if File.extname(id).to_s.empty?
-                 ".yml"
-               else
-                 File.extname(id)
-               end
-    end
-    alias_method :extension, :ext
 
     # Returns the file's sanitized slug (as used in `site.data[slug]`)
     def slug


### PR DESCRIPTION
Currently on `master`, `File.extname(id)` is called in 3 separate places, each returning the same value but different objects. This PR proposes *a minor optimization* by moving `File.extname(id)` into the initializer.