### PR TITLE
Expose data file's basename as attribute `name`

### DIFF
--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -96,7 +96,6 @@ module JekyllAdmin
     def basename_with_extension
       "#{basename}#{extension}"
     end
-    alias_method :filename, :basename_with_extension
     alias_method :name, :basename_with_extension
     public :name
 

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -2,7 +2,7 @@
 
 module JekyllAdmin
   class DataFile
-    METHODS_FOR_LIQUID = %w(path relative_path slug ext title).freeze
+    METHODS_FOR_LIQUID = %w(name path relative_path slug ext title).freeze
     EXTENSIONS = %w(yaml yml json csv).freeze
 
     include APIable
@@ -94,9 +94,11 @@ module JekyllAdmin
     end
 
     def basename_with_extension
-      [basename, extension].join
+      "#{basename}#{extension}"
     end
     alias_method :filename, :basename_with_extension
+    alias_method :name, :basename_with_extension
+    public :name
 
     def namespace
       "data"

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -28,12 +28,17 @@ describe JekyllAdmin::DataFile do
     expect(subject.slug).to eql("data_file")
   end
 
+  it "exposes the basename_with_extension as 'name'" do
+    expect(subject.name).to eql("data_file.yml")
+  end
+
   it "exposes the title" do
     expect(subject.title).to eql("Data File")
   end
 
   it "returns the hash" do
     expect(subject.to_api).to eql(
+      "name"          => "data_file.yml",
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
@@ -46,6 +51,7 @@ describe JekyllAdmin::DataFile do
 
   it "returns the hash with content" do
     expect(subject.to_api(:include_content => true)).to eql(
+      "name"          => "data_file.yml",
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -5,6 +5,7 @@ describe "data" do
 
   let(:base_response) do
     {
+      "name"          => "data_file.yml",
       "path"          => "/_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
@@ -44,6 +45,7 @@ describe "data" do
     get "/data/movies"
 
     expected_response = {
+      "name"          => "actors.yml",
       "path"          => "/_data/movies/actors.yml",
       "relative_path" => "movies/actors.yml",
       "slug"          => "actors",
@@ -61,6 +63,7 @@ describe "data" do
     get "/data/movies/actors.yml"
 
     expected_response = {
+      "name"          => "actors.yml",
       "path"          => "/_data/movies/actors.yml",
       "relative_path" => "movies/actors.yml",
       "slug"          => "actors",
@@ -82,6 +85,7 @@ describe "data" do
     delete_file "_data/data-file-new.yml"
 
     expected_response = {
+      "name"          => "data-file-new.yml",
       "path"          => "/_data/data-file-new.yml",
       "relative_path" => "data-file-new.yml",
       "slug"          => "data-file-new",
@@ -109,6 +113,7 @@ describe "data" do
     delete_file "_data/test-dir/data-file-new.yml"
 
     expected_response = {
+      "name"          => "data-file-new.yml",
       "path"          => "/_data/test-dir/data-file-new.yml",
       "relative_path" => "test-dir/data-file-new.yml",
       "slug"          => "data-file-new",
@@ -136,6 +141,7 @@ describe "data" do
     delete_file "_data/data-file-new.yml"
 
     expected_response = {
+      "name"          => "data-file-new.yml",
       "path"          => "/_data/data-file-new.yml",
       "relative_path" => "data-file-new.yml",
       "slug"          => "data-file-new",
@@ -163,6 +169,7 @@ describe "data" do
     delete_file "_data/test-dir/data-file-new.yml"
 
     expected_response = {
+      "name"          => "data-file-new.yml",
       "path"          => "/_data/test-dir/data-file-new.yml",
       "relative_path" => "test-dir/data-file-new.yml",
       "slug"          => "data-file-new",
@@ -190,6 +197,7 @@ describe "data" do
     write_file "_data/data-file-update.yml", "foo2: bar2"
 
     expected_response = {
+      "name"          => "data-file-update.yml",
       "path"          => "/_data/data-file-update.yml",
       "relative_path" => "data-file-update.yml",
       "slug"          => "data-file-update",
@@ -217,6 +225,7 @@ describe "data" do
     write_file "_data/test-dir/data-file-update.yml", "foo2: bar2"
 
     expected_response = {
+      "name"          => "data-file-update.yml",
       "path"          => "/_data/test-dir/data-file-update.yml",
       "relative_path" => "test-dir/data-file-update.yml",
       "slug"          => "data-file-update",
@@ -245,6 +254,7 @@ describe "data" do
     delete_file "_data/data-file-renamed.yml"
 
     expected_response = {
+      "name"          => "data-file-renamed.yml",
       "path"          => "/_data/data-file-renamed.yml",
       "relative_path" => "data-file-renamed.yml",
       "slug"          => "data-file-renamed",


### PR DESCRIPTION
This is to provide `JekyllAdmin::DataFile` instances parity with primitives from Jekyll.

`Jekyll::Page`, `Jekyll::Document`, `Jekyll::StaticFile` instances exposes their *basename with extension* via Liquid and therefore the API here as either `:name` or `:basename`