### PR TITLE
Allow custom labels for collections in sidebar

### DIFF
--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -44,7 +44,7 @@ export class Sidebar extends Component {
               to={`${ADMIN_PREFIX}/collections/${col.label}`}
             >
               <i className="fa fa-book" />
-              {capitalize(col.label)}
+              {col.sidebar_label || capitalize(col.label)}
             </Link>
           </li>
         );

--- a/src/containers/tests/__snapshots__/sidebar.spec.js.snap
+++ b/src/containers/tests/__snapshots__/sidebar.spec.js.snap
@@ -222,6 +222,139 @@ exports[`Containers::Sidebar renders correctly 1`] = `
 </div>
 `;
 
+exports[`Containers::Sidebar renders with custom collection labels 1`] = `
+<div
+  className="sidebar"
+>
+  <a
+    className="logo"
+    onClick={[Function]}
+    style={Object {}}
+  />
+  <ul
+    className="routes"
+  >
+    <li
+      className="accordion-label collapsed"
+      style={
+        Object {
+          "maxHeight": 50,
+        }
+      }
+    >
+      <a
+        onClick={[Function]}
+      >
+        <i
+          className="fa fa-book"
+        />
+        Collections
+        <div
+          className="counter"
+        >
+          2
+        </div>
+        <div
+          className="chevrons"
+        >
+          <i
+            className="fa fa-chevron-up"
+          />
+        </div>
+      </a>
+      <ul>
+        <li>
+          <a
+            onClick={[Function]}
+            style={Object {}}
+          >
+            <i
+              className="fa fa-book"
+            />
+            Tutorials
+          </a>
+        </li>
+        <li>
+          <a
+            onClick={[Function]}
+            style={Object {}}
+          >
+            <i
+              className="fa fa-book"
+            />
+            Docs
+          </a>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-book"
+        />
+        Posts
+      </a>
+    </li>
+    <div
+      className="splitter"
+    />
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-file-text"
+        />
+        Pages
+      </a>
+    </li>
+    <div
+      className="splitter"
+    />
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-database"
+        />
+        Data Files
+      </a>
+    </li>
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-file"
+        />
+        Static Files
+      </a>
+    </li>
+    <div
+      className="splitter"
+    />
+    <li>
+      <a
+        onClick={[Function]}
+        style={Object {}}
+      >
+        <i
+          className="fa fa-cog"
+        />
+        Configuration
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Containers::Sidebar renders with zero collections 1`] = `
 <div
   className="sidebar"

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -68,6 +68,24 @@ describe('Containers::Sidebar', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders with custom collection labels', () => {
+    const props = {
+      ...defaultProps,
+      collections: [
+        {
+          label: 'walkthroughs',
+          sidebar_label: 'Tutorials',
+        },
+        {
+          label: 'docs',
+        },
+      ],
+    };
+
+    const tree = renderer.create(<Sidebar {...props} {...actions} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('calls fetchCollections action after mounted', () => {
     expect(actions.fetchCollections).toHaveBeenCalled();
   });


### PR DESCRIPTION
By simply setting **`sidebar_label`** key in the collection's metadata..
Do note that the provided string value will be rendered as given without any capitalization or titlization. Additionally, only the sidebar will reflect this metadata. Breadcrumbs will continue to reflect the original type.

Closes #493 