### PR TITLE
Ensure a blank line at end of document

### DIFF
--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -74,6 +74,8 @@ module JekyllAdmin
               end
       body << "\n---\n\n"
       body << request_payload["raw_content"].to_s
+      body << "\n" unless body.end_with?("\n")
+      body
     end
     alias_method :page_body, :document_body
 


### PR DESCRIPTION
Currently, editing a page / document via the MarkdownEditor interface removes the blank line at the end of the file. This change ensures that a blank line is injected if it has been removed or doesn't exist otherwise.

*Not configurable at the moment.*