### PR TITLE
Filter away virtual pages that output to HTML file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gemspec
 # To allow testing with specific Jekyll versions
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
 
+# Fixture site dependencies
+gem "jekyll-redirect-from"
+
 # Site dependencies
 gem "jekyll-seo-tag"
 gem "jekyll-sitemap"

--- a/lib/jekyll-admin/server/pages.rb
+++ b/lib/jekyll-admin/server/pages.rb
@@ -55,7 +55,21 @@ module JekyllAdmin
       end
 
       def pages
-        site.pages.select(&:html?)
+        site.pages.select { |p| html_page_at_source?(p) }
+      end
+
+      # Test if a given page is *physically located* within the source directory and outputs
+      # to an HTML file.
+      # We don't want *virtual pages* that are generated via plugins.
+      def html_page_at_source?(page)
+        return false unless page.html?
+
+        # If page is not an instance of a `Jekyll::Page` subclass, then it needs additional
+        # inspection.
+        # Can't use `is_a?(Jekyll::Page)` here because it returns true for subclass instances
+        return true if page.class == Jekyll::Page
+
+        File.exist?(site.in_source_dir(page.relative_path))
       end
 
       def directory_pages

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -1,8 +1,9 @@
 title: Your awesome title
 
-# Load the admin interface.
+# Load the admin interface and some plugins for testing.
 plugins:
   - jekyll-admin
+  - jekyll-redirect-from
 
 # Exclude these files from being processed.
 exclude:

--- a/spec/fixtures/site/support.md
+++ b/spec/fixtures/site/support.md
@@ -1,0 +1,5 @@
+---
+redirect_from: '/webmaster.html'
+---
+
+Page to test redirection artefacts

--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -28,6 +28,10 @@ describe "pages" do
       get "/pages"
       expect(last_response).to be_ok
       expect(first_page["name"]).to eq("page.md")
+
+      redirect_page = JekyllAdmin.site.pages.find { |p| p.name == "redirect.html" }
+      expect(redirect_page.url).to eql("/webmaster.html")
+      expect(entries).to_not include(redirect_page.to_api)
     end
 
     it "lists directories" do


### PR DESCRIPTION
There is no point in rendering routes to *virtual pages*&mdash;those that do not have a physical presence within the `source` directory. Such `page` objects are always generated via a plugin.

For example, `jekyll-redirect-from` plugin generates a *virtual `page`* named `redirect.html`. Such pages exist only in-memory at runtime.

Fixes #428 