### PR TITLE
Strip leading slash from data file's path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ A `GET` call to the `api_url` will return another JSON object for the constituen
     "api_url": "http://localhost:4000/_api/data/books/genres/"
   },
   {
-    "path": "/_data/books/authors.yml",
+    "path": "_data/books/authors.yml",
     "relative_path": "books/authors.yml",
     "slug": "authors",
     "ext": ".yml",

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -56,7 +56,7 @@ module JekyllAdmin
 
     # Returns path relative to site source
     def path
-      File.join(DataFile.data_dir, relative_path)
+      @path ||= File.join(DataFile.data_dir, relative_path)
     end
 
     def absolute_path

--- a/lib/jekyll-admin/data_file.rb
+++ b/lib/jekyll-admin/data_file.rb
@@ -56,7 +56,7 @@ module JekyllAdmin
 
     # Returns path relative to site source
     def path
-      ensure_leading_slash(File.join(DataFile.data_dir, relative_path))
+      File.join(DataFile.data_dir, relative_path)
     end
 
     def absolute_path

--- a/spec/jekyll-admin/data_file_spec.rb
+++ b/spec/jekyll-admin/data_file_spec.rb
@@ -39,7 +39,7 @@ describe JekyllAdmin::DataFile do
   it "returns the hash" do
     expect(subject.to_api).to eql(
       "name"          => "data_file.yml",
-      "path"          => "/_data/data_file.yml",
+      "path"          => "_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
       "ext"           => ".yml",
@@ -52,7 +52,7 @@ describe JekyllAdmin::DataFile do
   it "returns the hash with content" do
     expect(subject.to_api(:include_content => true)).to eql(
       "name"          => "data_file.yml",
-      "path"          => "/_data/data_file.yml",
+      "path"          => "_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
       "ext"           => ".yml",

--- a/spec/jekyll-admin/server/data_spec.rb
+++ b/spec/jekyll-admin/server/data_spec.rb
@@ -6,7 +6,7 @@ describe "data" do
   let(:base_response) do
     {
       "name"          => "data_file.yml",
-      "path"          => "/_data/data_file.yml",
+      "path"          => "_data/data_file.yml",
       "relative_path" => "data_file.yml",
       "slug"          => "data_file",
       "ext"           => ".yml",
@@ -46,7 +46,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "actors.yml",
-      "path"          => "/_data/movies/actors.yml",
+      "path"          => "_data/movies/actors.yml",
       "relative_path" => "movies/actors.yml",
       "slug"          => "actors",
       "ext"           => ".yml",
@@ -64,7 +64,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "actors.yml",
-      "path"          => "/_data/movies/actors.yml",
+      "path"          => "_data/movies/actors.yml",
       "relative_path" => "movies/actors.yml",
       "slug"          => "actors",
       "ext"           => ".yml",
@@ -86,7 +86,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-new.yml",
-      "path"          => "/_data/data-file-new.yml",
+      "path"          => "_data/data-file-new.yml",
       "relative_path" => "data-file-new.yml",
       "slug"          => "data-file-new",
       "ext"           => ".yml",
@@ -114,7 +114,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-new.yml",
-      "path"          => "/_data/test-dir/data-file-new.yml",
+      "path"          => "_data/test-dir/data-file-new.yml",
       "relative_path" => "test-dir/data-file-new.yml",
       "slug"          => "data-file-new",
       "ext"           => ".yml",
@@ -142,7 +142,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-new.yml",
-      "path"          => "/_data/data-file-new.yml",
+      "path"          => "_data/data-file-new.yml",
       "relative_path" => "data-file-new.yml",
       "slug"          => "data-file-new",
       "ext"           => ".yml",
@@ -170,7 +170,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-new.yml",
-      "path"          => "/_data/test-dir/data-file-new.yml",
+      "path"          => "_data/test-dir/data-file-new.yml",
       "relative_path" => "test-dir/data-file-new.yml",
       "slug"          => "data-file-new",
       "ext"           => ".yml",
@@ -198,7 +198,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-update.yml",
-      "path"          => "/_data/data-file-update.yml",
+      "path"          => "_data/data-file-update.yml",
       "relative_path" => "data-file-update.yml",
       "slug"          => "data-file-update",
       "ext"           => ".yml",
@@ -226,7 +226,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-update.yml",
-      "path"          => "/_data/test-dir/data-file-update.yml",
+      "path"          => "_data/test-dir/data-file-update.yml",
       "relative_path" => "test-dir/data-file-update.yml",
       "slug"          => "data-file-update",
       "ext"           => ".yml",
@@ -255,7 +255,7 @@ describe "data" do
 
     expected_response = {
       "name"          => "data-file-renamed.yml",
-      "path"          => "/_data/data-file-renamed.yml",
+      "path"          => "_data/data-file-renamed.yml",
       "relative_path" => "data-file-renamed.yml",
       "slug"          => "data-file-renamed",
       "ext"           => ".yml",
@@ -269,7 +269,7 @@ describe "data" do
     }
 
     request = {
-      "path"    => "/_data/data-file-renamed.yml",
+      "path"    => "_data/data-file-renamed.yml",
       "content" => { "foo" => "bar2" },
     }
     put "/data/data-file-rename.yml", request.to_json


### PR DESCRIPTION
Since it is redundant and two path segments are joined at the back end via `File.join` which inserts the slash when generating an absolute path.