### PR TITLE
Optimize API Hash objects

### DIFF
--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -22,6 +22,8 @@ module JekyllAdmin
     #                   to support mapping on indexes where we only want metadata
     #
     # Returns a hash (which can then be to_json'd)
+    #
+    # rubocop:disable Metrics/AbcSize
     def to_api(include_content: false)
       output = API_SCAFFOLD.merge hash_for_api
 
@@ -55,6 +57,7 @@ module JekyllAdmin
       output.merge!(url_fields)
       output
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -5,6 +5,7 @@ module JekyllAdmin
   # additional, API-specific functionality without duplicating logic
   module APIable
     CONTENT_FIELDS = %w(next previous content excerpt).freeze
+    API_SCAFFOLD   = %w(name path).map { |i| [i, nil] }.to_h.freeze
 
     # Returns a hash suitable for use as an API response.
     #
@@ -23,8 +24,7 @@ module JekyllAdmin
     #
     # Returns a hash (which can then be to_json'd)
     def to_api(include_content: false)
-      output = hash_for_api
-      output = output.merge(url_fields)
+      output = API_SCAFFOLD.merge hash_for_api
 
       # Include content, if requested, otherwise remove it
       if include_content
@@ -41,6 +41,8 @@ module JekyllAdmin
       # array with each rendered document, which we don't want.
       if is_a?(Jekyll::Collection)
         output.delete("docs")
+        output["name"] = label
+        output["path"] = relative_directory
         output["entries_url"] = entries_url
       end
 
@@ -51,6 +53,7 @@ module JekyllAdmin
 
       output["from_theme"] = from_theme_gem? if is_a?(Jekyll::StaticFile)
 
+      output = output.merge(url_fields)
       output
     end
 

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -21,14 +21,13 @@ module JekyllAdmin
     # include_content - if true, includes the content in the respond, false by default
     #                   to support mapping on indexes where we only want metadata
     #
-    #
     # Returns a hash (which can then be to_json'd)
     def to_api(include_content: false)
       output = API_SCAFFOLD.merge hash_for_api
 
       # Include content, if requested, otherwise remove it
       if include_content
-        output = output.merge(content_fields)
+        output.merge!(content_fields)
       else
         CONTENT_FIELDS.each { |field| output.delete(field) }
       end
@@ -53,7 +52,7 @@ module JekyllAdmin
 
       output["from_theme"] = from_theme_gem? if is_a?(Jekyll::StaticFile)
 
-      output = output.merge(url_fields)
+      output.merge!(url_fields)
       output
     end
 


### PR DESCRIPTION
- `API_SCAFFOLD` is the base hash with each key pointing to a `nil` value. When merged with the API generated via calling `#hash_for_api`, the values of the base API will get updated. Therefore, the first two keys of the final api hash from calling `#to_api` will always be "name" and "path".
The url fields ("http_url", "api_url", and collections' "entries_url") are injected towards the end so that they are always the last keys of the api hash.
- Use `Hash#merge!` for subsequent merges to avoid generating a new Hash object unnecessarily.