### PR TITLE
Add support for baseurl

### DIFF
--- a/lib/jekyll-admin.rb
+++ b/lib/jekyll-admin.rb
@@ -39,6 +39,17 @@ module JekyllAdmin
   end
 end
 
+require_relative "jekyll-admin/bundle_munger"
+
+# When not running in *development* mode, if a site's baseurl has been set to non-empty string,
+# copy the admin interface bundle into the site's destination directory and adjust the interface
+# references within.
+unless ENV["RACK_ENV"] == "development"
+  Jekyll::Hooks.register :site, :post_write do |site|
+    JekyllAdmin::BundleMunger.new(site).inject
+  end
+end
+
 [Jekyll::Page, Jekyll::Document, Jekyll::StaticFile, Jekyll::Collection].each do |klass|
   klass.include JekyllAdmin::APIable
   klass.include JekyllAdmin::URLable

--- a/lib/jekyll-admin/bundle_munger.rb
+++ b/lib/jekyll-admin/bundle_munger.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module JekyllAdmin
+  # A class to modify the admin interface bundle based on site's baseurl configuration
+  class BundleMunger
+    ASSETS_TO_MUNGE = %w(index.html bundle.js styles.css).freeze
+    PUBLIC_DIR_PATH = File.expand_path("public", __dir__).freeze
+    private_constant :ASSETS_TO_MUNGE, :PUBLIC_DIR_PATH
+
+    def initialize(site)
+      @site     = site
+      @dest_dir = site.in_dest_dir("admin")
+      @injected = false
+    end
+
+    def inject
+      return if site.baseurl.nil? || site.baseurl == ""
+      return if File.directory?(dest_dir) && @injected
+
+      inject_and_munge_assets
+      @injected = true
+    rescue StandardError
+      @injected = false
+    end
+
+    private
+
+    attr_reader :site, :dest_dir
+
+    def inject_and_munge_assets
+      # Ensure Jekyll::Cleaner doesn't remove the interface files on regeneration
+      site.keep_files << "admin/"
+
+      FileUtils.mkdir_p(dest_dir)
+      FileUtils.cp_r(PUBLIC_DIR_PATH + "/.", dest_dir)
+
+      admin_with_baseurl = "/#{cleaned_baseurl}/admin"
+      ASSETS_TO_MUNGE.each do |asset|
+        src_path  = File.join(PUBLIC_DIR_PATH, asset)
+        dest_path = File.join(dest_dir, asset)
+        File.open(dest_path, "wb") do |f|
+          f.puts(
+            File.binread(src_path).gsub("/admin", admin_with_baseurl)
+          )
+        end
+      end
+    end
+
+    # site.baseurl stripped of any leading or trailing slashes and multiple slashes
+    # swapped with a single slash.
+    def cleaned_baseurl
+      @cleaned_baseurl ||= site.baseurl.squeeze("/").gsub(%r!\A/+|/+\z!, "")
+    end
+  end
+end

--- a/lib/jekyll/commands/serve.rb
+++ b/lib/jekyll/commands/serve.rb
@@ -20,8 +20,11 @@ module Jekyll
         end
 
         def jekyll_admin_monkey_patch
-          @server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
-          @server.mount "/_api",  Rack::Handler::WEBrick, JekyllAdmin::Server
+          site = JekyllAdmin.site
+          unless site.baseurl.nil? || site.baseurl == ""
+            @server.mount "/admin", Rack::Handler::WEBrick, JekyllAdmin::StaticServer
+          end
+          @server.mount "/_api", Rack::Handler::WEBrick, JekyllAdmin::Server
           Jekyll.logger.info "JekyllAdmin mode:", ENV["RACK_ENV"] || "production"
         end
       end


### PR DESCRIPTION
- Support for `baseurl` in `production` mode.
- ***Copies entire front end bundle for admin interface to `<site.destination>/admin/`***
- API is still mounted at `/_api/`