### PR TITLE
Move common function in ducks to utility module

### DIFF
--- a/src/containers/views/DataFiles.js
+++ b/src/containers/views/DataFiles.js
@@ -9,12 +9,8 @@ import Breadcrumbs from '../../components/Breadcrumbs';
 import { getDeleteMessage, getNotFoundMessage } from '../../translations';
 import InputSearch from '../../components/form/InputSearch';
 import Button from '../../components/Button';
-import {
-  fetchDataFiles,
-  deleteDataFile,
-  filterByFilename,
-} from '../../ducks/datafiles';
-import { search } from '../../ducks/utils';
+import { fetchDataFiles, deleteDataFile } from '../../ducks/datafiles';
+import { search, filterBySearchInput } from '../../ducks/utils';
 import { getFilenameFromPath } from '../../utils/helpers';
 import { ADMIN_PREFIX } from '../../constants';
 
@@ -163,7 +159,7 @@ DataFiles.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  files: filterByFilename(state.datafiles.files, state.utils.input),
+  files: filterBySearchInput(state.datafiles.files, state.utils.input),
   isFetching: state.datafiles.isFetching,
 });
 

--- a/src/containers/views/Drafts.js
+++ b/src/containers/views/Drafts.js
@@ -8,14 +8,10 @@ import DocumentTitle from 'react-document-title';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Button from '../../components/Button';
 import InputSearch from '../../components/form/InputSearch';
-import { search } from '../../ducks/utils';
+import { search, filterBySearchInput } from '../../ducks/utils';
 import { getDeleteMessage, getNotFoundMessage } from '../../translations';
 import { ADMIN_PREFIX } from '../../constants';
-import {
-  fetchDrafts,
-  deleteDraft,
-  filterBySearchInput,
-} from '../../ducks/drafts';
+import { fetchDrafts, deleteDraft } from '../../ducks/drafts';
 
 export class Drafts extends Component {
   componentDidMount() {

--- a/src/containers/views/Pages.js
+++ b/src/containers/views/Pages.js
@@ -8,8 +8,8 @@ import DocumentTitle from 'react-document-title';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import Button from '../../components/Button';
 import InputSearch from '../../components/form/InputSearch';
-import { fetchPages, deletePage, filterBySearchInput } from '../../ducks/pages';
-import { search } from '../../ducks/utils';
+import { fetchPages, deletePage } from '../../ducks/pages';
+import { search, filterBySearchInput } from '../../ducks/utils';
 import { getDeleteMessage, getNotFoundMessage } from '../../translations';
 import { ADMIN_PREFIX } from '../../constants';
 

--- a/src/ducks/datafiles.js
+++ b/src/ducks/datafiles.js
@@ -196,13 +196,3 @@ export default function datafiles(
       };
   }
 }
-
-// Selectors
-export const filterByFilename = (datafiles, input) => {
-  if (input) {
-    return _.filter(datafiles, file => {
-      return file.path.toLowerCase().includes(input.toLowerCase());
-    });
-  }
-  return datafiles;
-};

--- a/src/ducks/drafts.js
+++ b/src/ducks/drafts.js
@@ -172,11 +172,3 @@ export default function drafts(
       };
   }
 }
-
-// Selectors
-export const filterBySearchInput = (list, input) => {
-  if (input) {
-    return list.filter(p => p.name.toLowerCase().includes(input.toLowerCase()));
-  }
-  return list;
-};

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -188,11 +188,3 @@ export default function pages(
       };
   }
 }
-
-// Selectors
-export const filterBySearchInput = (list, input) => {
-  if (input) {
-    return list.filter(p => p.name.toLowerCase().includes(input.toLowerCase()));
-  }
-  return list;
-};

--- a/src/ducks/reducer_tests/datafiles.spec.js
+++ b/src/ducks/reducer_tests/datafiles.spec.js
@@ -1,5 +1,5 @@
 import * as datafilesDuck from '../datafiles';
-import { datafile, data_files } from './fixtures';
+import { datafile } from './fixtures';
 
 const reducer = datafilesDuck.default;
 
@@ -131,10 +131,5 @@ describe('Reducers::DataFiles', () => {
       datafileChanged: true,
       updated: false,
     });
-  });
-
-  it('should filter data files and directories', () => {
-    expect(datafilesDuck.filterByFilename(data_files, '').length).toBe(2);
-    expect(datafilesDuck.filterByFilename(data_files, '.yml').length).toBe(1);
   });
 });

--- a/src/ducks/reducer_tests/drafts.spec.js
+++ b/src/ducks/reducer_tests/drafts.spec.js
@@ -1,5 +1,5 @@
 import * as draftsDuck from '../drafts';
-import { draft, draft_entries } from './fixtures';
+import { draft } from './fixtures';
 
 const reducer = draftsDuck.default;
 
@@ -102,12 +102,5 @@ describe('Reducers::Drafts', () => {
     expect(reducer({ updated: true }, {})).toEqual({
       updated: false,
     });
-  });
-
-  it('should filter drafts and directories', () => {
-    expect(draftsDuck.filterBySearchInput(draft_entries, '').length).toBe(2);
-    expect(draftsDuck.filterBySearchInput(draft_entries, 'post').length).toBe(
-      1
-    );
   });
 });

--- a/src/ducks/reducer_tests/fixtures/index.js
+++ b/src/ducks/reducer_tests/fixtures/index.js
@@ -115,6 +115,7 @@ export const meta = {
 };
 
 export const datafile = {
+  name: "data_file.yml",
   path: "_data/data_file.yml",
   relative_path: "_data/data_file.yml",
   slug: "data_file",

--- a/src/ducks/reducer_tests/pages.spec.js
+++ b/src/ducks/reducer_tests/pages.spec.js
@@ -103,8 +103,4 @@ describe('Reducers::Pages', () => {
       updated: false,
     });
   });
-
-  it('should filter pages and directories', () => {
-    expect(pagesDuck.filterBySearchInput(page_entries, 'gsoc').length).toBe(1);
-  });
 });

--- a/src/ducks/reducer_tests/utils.spec.js
+++ b/src/ducks/reducer_tests/utils.spec.js
@@ -1,4 +1,5 @@
 import * as utilsDuck from '../utils';
+import { page_entries, draft_entries, data_files } from './fixtures';
 
 const reducer = utilsDuck.default;
 
@@ -49,5 +50,15 @@ describe('Reducers::Utils', () => {
     ).toEqual({
       errors: ['The title is required'],
     });
+  });
+
+  it('should filter files and directories by input', () => {
+    expect(utilsDuck.filterBySearchInput(page_entries, 'gsoc').length).toBe(1);
+
+    expect(utilsDuck.filterBySearchInput(draft_entries, '').length).toBe(2);
+    expect(utilsDuck.filterBySearchInput(draft_entries, 'post').length).toBe(1);
+
+    expect(utilsDuck.filterBySearchInput(data_files, '').length).toBe(2);
+    expect(utilsDuck.filterBySearchInput(data_files, '.yml').length).toBe(1);
   });
 });

--- a/src/ducks/utils.js
+++ b/src/ducks/utils.js
@@ -1,3 +1,11 @@
+// Selectors
+export const filterBySearchInput = (list, input) => {
+  if (input) {
+    return list.filter(p => p.name.toLowerCase().includes(input.toLowerCase()));
+  }
+  return list;
+};
+
 // Action Types
 export const SEARCH_CONTENT = 'SEARCH_CONTENT';
 export const CLEAR_ERRORS = 'CLEAR_ERRORS';


### PR DESCRIPTION
At the time the filter function was written for data files, the latter resources didn't have a `name` property. However, now they do.
But on modifying the function to filter by filename, it became evident that the functions defined in ducks for pages, drafts and data files **are now identical** and can therefore be extracted as a utility function.