### PR TITLE
Render icons in Button based on the `type` prop

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,6 +3,15 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { labels } from '../translations';
 
+const iconMap = {
+  create: 'plus-square',
+  delete: 'trash',
+  publish: 'send-o',
+  save: 'save',
+  upload: 'upload',
+  view: 'eye',
+};
+
 export default function Button({
   type,
   active,
@@ -53,6 +62,8 @@ export default function Button({
     default:
   }
 
+  const iconName = icon || iconMap[type];
+
   return (
     <a
       href={to}
@@ -60,7 +71,7 @@ export default function Button({
       onClick={to ? null : onClick}
       className={btnClass}
     >
-      {icon && <i className={`fa fa-${icon}`} aria-hidden="true" />}
+      {iconName && <i className={`fa fa-${iconName}`} aria-hidden="true" />}
       {triggered ? triggeredLabel : label}
     </a>
   );

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -52,7 +52,7 @@ export default class Explorer extends Component {
             <Button
               onClick={() => this.handleClickDelete(name)}
               type="delete"
-              active={true}
+              active
               thin
             />
             {http_url && <Button to={http_url} type="view" active thin />}

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -52,13 +52,10 @@ export default class Explorer extends Component {
             <Button
               onClick={() => this.handleClickDelete(name)}
               type="delete"
-              icon="trash"
               active={true}
               thin
             />
-            {http_url && (
-              <Button to={http_url} type="view" icon="eye" active thin />
-            )}
+            {http_url && <Button to={http_url} type="view" active thin />}
           </div>
         </td>
       </tr>

--- a/src/components/tests/button.spec.js
+++ b/src/components/tests/button.spec.js
@@ -23,7 +23,7 @@ describe('Components::Button', () => {
   it('should render correctly', () => {
     let { link, icon } = setup();
     expect(link.text()).toBe('Save');
-    expect(icon.node).toBeFalsy();
+    expect(icon.node).toBeTruthy();
 
     link = setup({
       ...defaultProps,
@@ -59,8 +59,9 @@ describe('Components::Button', () => {
     expect(link.text()).toBe('Switch View to Raw Editor');
   });
 
-  it('should render icon', () => {
-    const { icon } = setup({ ...defaultProps, icon: 'eye' });
+  it('should render custom icon', () => {
+    const { link, icon } = setup({ ...defaultProps, icon: 'eye' });
+    expect(link.text()).toBe('Save');
     expect(icon.node).toBeTruthy();
   });
 

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -193,7 +193,6 @@ export class DataFileEdit extends Component {
           type="save"
           active={activator}
           triggered={updated}
-          icon="save"
           block
         />
         {guiSupport && (
@@ -209,7 +208,6 @@ export class DataFileEdit extends Component {
         <Button
           onClick={() => this.handleClickDelete(filename)}
           type="delete"
-          icon="trash"
           active
           block
         />

--- a/src/containers/views/DataFileNew.js
+++ b/src/containers/views/DataFileNew.js
@@ -174,7 +174,6 @@ export class DataFileNew extends Component {
                 type="create"
                 active={activator}
                 triggered={updated}
-                icon="plus-square"
                 block
               />
               <Button

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -168,17 +168,13 @@ export class DocumentEdit extends Component {
                 type="save"
                 active={fieldChanged}
                 triggered={updated}
-                icon="save"
                 block
               />
-              {http_url && (
-                <Button to={http_url} type="view" icon="eye" active block />
-              )}
+              {http_url && <Button to={http_url} type="view" active block />}
               <Splitter />
               <Button
                 onClick={this.handleClickDelete}
                 type="delete"
-                icon="trash"
                 active
                 block
               />

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -114,7 +114,6 @@ export class DocumentNew extends Component {
                 type="create"
                 active={fieldChanged}
                 triggered={updated}
-                icon="plus-square"
                 block
               />
             </div>

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -85,13 +85,10 @@ export class Documents extends Component {
             <Button
               onClick={() => this.handleClickDelete(name)}
               type="delete"
-              icon="trash"
               active
               thin
             />
-            {http_url && (
-              <Button to={http_url} type="view" icon="eye" active thin />
-            )}
+            {http_url && <Button to={http_url} type="view" active thin />}
           </div>
         </td>
       </tr>

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -184,22 +184,19 @@ export class DraftEdit extends Component {
                 type="save"
                 active={fieldChanged}
                 triggered={updated}
-                icon="save"
                 block
               />
-              <Button to={http_url} type="view" icon="eye" active block />
+              <Button to={http_url} type="view" active block />
               <Splitter />
               <Button
                 onClick={() => this.handleClickPublish(path)}
                 type="publish"
-                icon="send-o"
                 active
                 block
               />
               <Button
                 onClick={() => this.handleClickDelete(name)}
                 type="delete"
-                icon="trash"
                 active
                 block
               />

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -107,7 +107,6 @@ export class DraftNew extends Component {
                 type="create"
                 active={fieldChanged}
                 triggered={updated}
-                icon="plus-square"
                 block
               />
             </div>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -148,15 +148,13 @@ export class PageEdit extends Component {
                 type="save"
                 active={fieldChanged}
                 triggered={updated}
-                icon="save"
                 block
               />
-              <Button to={http_url} type="view" icon="eye" active block />
+              <Button to={http_url} type="view" active block />
               <Splitter />
               <Button
                 onClick={() => this.handleClickDelete(name)}
                 type="delete"
-                icon="trash"
                 active
                 block
               />

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -107,7 +107,6 @@ export class PageNew extends Component {
                 type="create"
                 active={fieldChanged}
                 triggered={updated}
-                icon="plus-square"
                 block
               />
             </div>

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -135,7 +135,6 @@ export class StaticFiles extends Component {
               <Button
                 onClick={() => this.openDropzone()}
                 type="upload"
-                icon="upload"
                 active
               />
             </div>

--- a/src/containers/views/StaticIndex.js
+++ b/src/containers/views/StaticIndex.js
@@ -5,7 +5,6 @@ import { bindActionCreators } from 'redux';
 import _ from 'underscore';
 import DocumentTitle from 'react-document-title';
 import FilePreview from '../../components/FilePreview';
-import Button from '../../components/Button';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import InputSearch from '../../components/form/InputSearch';
 import { search } from '../../ducks/utils';


### PR DESCRIPTION
Most of the buttons have their icons fixed for a given type to ease UX. For example, `delete` type buttons are always rendered with the `trash` icon, or the `view` buttons are always rendered with the `eye` icon and similarly the `save` buttons are always rendered with the `save (floppy)` icon.

So instead of having to repeatedly pass the icon-name as a prop for the same Button type, it is better if the Button component determined the icon based on the current type.

Nevertheless, the existing behavior of passing `icon` as a prop is still valid to allow rendering a *variant* of the button with a different icon if such a need arises.