### PR TITLE
Compact switch statement in Button component

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -48,7 +48,7 @@ export default function Button({
     case 'delete':
     case 'upload':
     case 'publish':
-      label = labels[type]['label'];
+      label = labels[type].label;
       break;
     default:
   }

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -29,7 +29,7 @@ export default function Button({
     case 'save':
     case 'create':
       label = labels[type].label;
-      triggeredLabel = labels[type]['triggeredLabel'];
+      triggeredLabel = labels[type].triggeredLabel;
       break;
     case 'view-toggle':
       label = labels.viewToggle.label;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -28,7 +28,7 @@ export default function Button({
   switch (type) {
     case 'save':
     case 'create':
-      label = labels[type]['label'];
+      label = labels[type].label;
       triggeredLabel = labels[type]['triggeredLabel'];
       break;
     case 'view-toggle':

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -27,28 +27,19 @@ export default function Button({
   let triggeredLabel = '';
   switch (type) {
     case 'save':
-      label = labels.save.label;
-      triggeredLabel = labels.save.triggeredLabel;
-      break;
     case 'create':
-      label = labels.create.label;
-      triggeredLabel = labels.create.triggeredLabel;
-      break;
-    case 'delete':
-      label = labels.delete.label;
-      break;
-    case 'view':
-      label = labels.view.label;
-      break;
-    case 'upload':
-      label = labels.upload.label;
+      label = labels[type]['label'];
+      triggeredLabel = labels[type]['triggeredLabel'];
       break;
     case 'view-toggle':
       label = labels.viewToggle.label;
       triggeredLabel = labels.viewToggle.triggeredLabel;
       break;
+    case 'view':
+    case 'delete':
+    case 'upload':
     case 'publish':
-      label = labels.publish.label;
+      label = labels[type]['label'];
       break;
     default:
   }


### PR DESCRIPTION
Instead of using separate statements involving dot-notation, *bracket-notation* can be used to dynamically interpolate property key and consequently reduce the no. of statements in the `switch()` expression.