### PR TITLE
Return static file's relative_path not http_url

### DIFF
--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -45,7 +45,7 @@ export default class FilePreview extends Component {
     );
 
     const nodeLink = onClick ? (
-      <a onClick={onClick.bind(null, file.http_url)}>{node}</a>
+      <a onClick={() => onClick(file.relative_path)}>{node}</a>
     ) : (
       <a href={file.http_url} target="_blank">
         {node}


### PR DESCRIPTION
So that the user doesn't have to manually remove `http://localhost:4000/` from the value returned by the image-picker modal.