### PR TITLE
Remove unused action

### DIFF
--- a/docs/_frontend/actions.md
+++ b/docs/_frontend/actions.md
@@ -142,10 +142,6 @@ Updates the content body when the markdown editor changes.
 
 Updates the content path when the input changes.
 
-### `updateDraft(isDraft)`
-
-Updates the content visibility when the checkbox changes.
-
 ## Static Files
 
 ### `fetchStaticFiles`

--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -161,7 +161,6 @@ Container for creating a new page.
   updateTitle: Function,
   updateBody: Function,
   updatePath: Function,
-  updateDraft: Function,
   clearErrors: Function,
   errors: Array,
   fieldChanged: Boolean
@@ -221,7 +220,6 @@ Container for creating a new document.
   updateTitle: Function,
   updateBody: Function,
   updatePath: Function,
-  updateDraft: Function,
   clearErrors: Function,
   errors: Array,
   fieldChanged: Boolean
@@ -255,7 +253,6 @@ Container for creating a new draft.
   updateTitle: Function,
   updateBody: Function,
   updatePath: Function,
-  updateDraft: Function,
   clearErrors: Function,
   errors: Array,
   fieldChanged: Boolean,

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -20,12 +20,7 @@ import { getLeaveMessage } from '../../translations';
 import { injectDefaultFields } from '../../utils/metadata';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
 import { ADMIN_PREFIX } from '../../constants';
-import {
-  updateTitle,
-  updateBody,
-  updatePath,
-  updateDraft,
-} from '../../ducks/metadata';
+import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 
 export class DraftNew extends Component {
   componentDidMount() {
@@ -122,7 +117,6 @@ DraftNew.propTypes = {
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
-  updateDraft: PropTypes.func.isRequired,
   clearErrors: PropTypes.func.isRequired,
   errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
@@ -148,7 +142,6 @@ const mapDispatchToProps = dispatch =>
       updateTitle,
       updateBody,
       updatePath,
-      updateDraft,
       putDraft,
       clearErrors,
     },

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -14,12 +14,7 @@ import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import StaticMetaData from '../../components/metadata/StaticMetaFields';
 import Metadata from '../../containers/MetaFields';
-import {
-  updateTitle,
-  updateBody,
-  updatePath,
-  updateDraft,
-} from '../../ducks/metadata';
+import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { createPage } from '../../ducks/pages';
 import { clearErrors } from '../../ducks/utils';
 import { getLeaveMessage } from '../../translations';
@@ -122,7 +117,6 @@ PageNew.propTypes = {
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
   updatePath: PropTypes.func.isRequired,
-  updateDraft: PropTypes.func.isRequired,
   clearErrors: PropTypes.func.isRequired,
   errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
@@ -148,7 +142,6 @@ const mapDispatchToProps = dispatch =>
       updateTitle,
       updateBody,
       updatePath,
-      updateDraft,
       createPage,
       clearErrors,
     },

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -27,7 +27,6 @@ const setup = (props = defaultProps) => {
     updateTitle: jest.fn(),
     updateBody: jest.fn(),
     updatePath: jest.fn(),
-    updateDraft: jest.fn(),
     clearErrors: jest.fn(),
   };
 

--- a/src/containers/views/tests/pagenew.spec.js
+++ b/src/containers/views/tests/pagenew.spec.js
@@ -24,7 +24,6 @@ function setup(props = defaultProps) {
     updateTitle: jest.fn(),
     updateBody: jest.fn(),
     updatePath: jest.fn(),
-    updateDraft: jest.fn(),
     clearErrors: jest.fn(),
   };
 

--- a/src/ducks/action_tests/metadata.spec.js
+++ b/src/ducks/action_tests/metadata.spec.js
@@ -95,14 +95,6 @@ describe('Actions::Metadata', () => {
     expect(metadataDuck.updateBody('Test Body')).toEqual(expectedAction);
   });
 
-  it('creates UPDATE_DRAFT', () => {
-    const expectedAction = {
-      type: metadataDuck.UPDATE_DRAFT,
-      draft: false,
-    };
-    expect(metadataDuck.updateDraft(false)).toEqual(expectedAction);
-  });
-
   it('creates UPDATE_PATH', () => {
     const expectedAction = {
       type: metadataDuck.UPDATE_PATH,

--- a/src/ducks/metadata.js
+++ b/src/ducks/metadata.js
@@ -11,7 +11,6 @@ import {
 export const UPDATE_TITLE = 'UPDATE_TITLE';
 export const UPDATE_BODY = 'UPDATE_BODY';
 export const UPDATE_PATH = 'UPDATE_PATH';
-export const UPDATE_DRAFT = 'UPDATE_DRAFT';
 export const STORE_CONTENT_FIELDS = 'STORE_CONTENT_FIELDS';
 export const ADD_METAFIELD = 'ADD_METAFIELD';
 export const REMOVE_METAFIELD = 'REMOVE_METAFIELD';
@@ -73,11 +72,6 @@ export const updateBody = body => ({
   body,
 });
 
-export const updateDraft = draft => ({
-  type: UPDATE_DRAFT,
-  draft,
-});
-
 export const updatePath = path => ({
   type: UPDATE_PATH,
   path,
@@ -118,15 +112,6 @@ export default function metadata( // TODO normalize the metadata
         metadata: {
           ...state.metadata,
           path: action.path,
-        },
-        fieldChanged: true,
-      };
-    case UPDATE_DRAFT:
-      return {
-        ...state,
-        draft: {
-          ...state.metadata,
-          draft: action.draft,
         },
         fieldChanged: true,
       };


### PR DESCRIPTION
The action got left behind and became redundant as surrounding code got refactored across multiple releases.