### PR TITLE
Extract static-file picker logic into a component

### DIFF
--- a/src/components/FilePicker.js
+++ b/src/components/FilePicker.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'react-modal';
+import StaticIndex from '../containers/views/StaticIndex';
+import Icon from './Icon';
+
+export default class FilePicker extends Component {
+  state = {
+    showModal: false,
+  };
+
+  customStyles = {
+    overlay: {
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      zIndex: 10,
+    },
+    content: {
+      margin: 20,
+      paddingTop: 0,
+      paddingRight: 10,
+      paddingLeft: 15,
+    },
+  };
+
+  openModal = () => this.setState({ showModal: true });
+  shutModal = () => this.setState({ showModal: false });
+
+  onPickItem = path => {
+    this.props.onPick(path);
+    this.shutModal();
+  };
+
+  render() {
+    return (
+      <span className="images-wrapper">
+        <button onClick={this.openModal} ref="trigger">
+          <Icon name="picture-o" />
+        </button>
+        <Modal
+          isOpen={this.state.showModal}
+          contentLabel="FilePicker"
+          onRequestClose={this.shutModal}
+          style={this.customStyles}
+        >
+          <div className="content">
+            <StaticIndex onClickStaticFile={this.onPickItem} modalView />
+          </div>
+        </Modal>
+      </span>
+    );
+  }
+}
+
+FilePicker.propTypes = {
+  onPick: PropTypes.func.isRequired,
+};

--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -7,24 +7,12 @@ import moment from 'moment';
 import momentLocalizer from 'react-widgets/lib/localizers/moment';
 import StaticIndex from '../../containers/views/StaticIndex';
 import Icon from '../Icon';
+import FilePicker from '../FilePicker';
 import 'react-widgets/dist/css/react-widgets.css';
 
 momentLocalizer(moment);
 
 export class MetaSimple extends Component {
-  state = {
-    staticfiles: [],
-    showModal: false,
-  };
-
-  handleOpenModal = () => {
-    this.setState({ showModal: true });
-  };
-
-  handleCloseModal = () => {
-    this.setState({ showModal: false });
-  };
-
   handleEditableChange = e => {
     const { nameAttr, updateFieldValue } = this.props;
     updateFieldValue(nameAttr, e.target.value);
@@ -66,11 +54,10 @@ export class MetaSimple extends Component {
     );
   }
 
-  onClickPickerItem = url => {
+  onPickItem = path => {
     const { nameAttr, updateFieldValue } = this.props;
-    this.refs.imagepicker.value = url;
-    updateFieldValue(nameAttr, url);
-    this.handleCloseModal();
+    this.refs.imagepicker.value = path;
+    updateFieldValue(nameAttr, path);
   };
 
   renderStaticFilePicker() {
@@ -83,36 +70,7 @@ export class MetaSimple extends Component {
           value={fieldValue}
           ref="imagepicker"
         />
-        <span className="images-wrapper">
-          <button onClick={this.handleOpenModal}>
-            <Icon name="picture-o" />
-          </button>
-          <Modal
-            isOpen={this.state.showModal}
-            onAfterOpen={this.fetchStaticFiles}
-            contentLabel="onRequestClose Example"
-            onRequestClose={this.handleCloseModal}
-            style={{
-              overlay: {
-                backgroundColor: 'rgba(0,0,0,0.6)',
-                zIndex: 10,
-              },
-              content: {
-                margin: 20,
-                paddingTop: 0,
-                paddingRight: 10,
-                paddingLeft: 15,
-              },
-            }}
-          >
-            <div className="content">
-              <StaticIndex
-                onClickStaticFile={url => this.onClickPickerItem(url)}
-                modalView={true}
-              />
-            </div>
-          </Modal>
-        </span>
+        <FilePicker onPick={this.onPickItem} />
       </div>
     );
   }

--- a/src/components/tests/filepicker.spec.js
+++ b/src/components/tests/filepicker.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Modal from 'react-modal';
+
+import FilePicker from '../FilePicker';
+
+function setup() {
+  const actions = {
+    onPick: jest.fn(),
+  };
+
+  let component = shallow(<FilePicker {...actions} />);
+
+  return {
+    component,
+    trigger: component.find('.images-wrapper > button'),
+    modal: component.find(Modal).first(),
+    actions,
+  };
+}
+
+describe('Components::FilePicker', () => {
+  it('should render correctly', () => {
+    const { component, trigger, modal } = setup();
+    expect(trigger.node).toBeTruthy();
+    expect(component.state('showModal')).toBe(false);
+    expect(modal.prop('isOpen')).toBe(false);
+  });
+
+  it('should render a modal on clicking the trigger', () => {
+    const { component, trigger } = setup();
+    trigger.simulate('click');
+    expect(component.state('showModal')).toBe(true);
+    const modal = component.find(Modal).first();
+    expect(modal.prop('isOpen')).toBe(true);
+  });
+
+  it('should exit the modal on requesting to close', () => {
+    const { component, trigger } = setup();
+    trigger.simulate('click');
+    expect(component.state('showModal')).toBe(true);
+    let modal = component.find(Modal).first();
+    expect(modal.prop('isOpen')).toBe(true);
+
+    component.setState({ showModal: false });
+    modal = component.find(Modal).first();
+    expect(modal.prop('isOpen')).toBe(false);
+  });
+});


### PR DESCRIPTION
In order to:
  - remove modal state from `MetaSimple` component.
  - facilitate wiring into MarkdownEditor in future.