### PR TITLE
DRY `*New` views with a higher-order-function

### DIFF
--- a/src/containers/views/ComposeCreator.js
+++ b/src/containers/views/ComposeCreator.js
@@ -2,15 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { browserHistory, withRouter } from 'react-router';
-import DocumentTitle from 'react-document-title';
-import CreateMarkdownPage from '../../components/CreateMarkdownPage';
+import { withRouter } from 'react-router';
 import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
-import { createPage } from '../../ducks/pages';
 import { clearErrors } from '../../ducks/utils';
 import { getLeaveMessage } from '../../translations';
-import { preventDefault, getDocumentTitle } from '../../utils/helpers';
-import { ADMIN_PREFIX } from '../../constants';
 
 export const compose_creator = WrappedComponent => {
   class ComposeCreator extends Component {

--- a/src/containers/views/ComposeCreator.js
+++ b/src/containers/views/ComposeCreator.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { browserHistory, withRouter } from 'react-router';
+import DocumentTitle from 'react-document-title';
+import CreateMarkdownPage from '../../components/CreateMarkdownPage';
+import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
+import { createPage } from '../../ducks/pages';
+import { clearErrors } from '../../ducks/utils';
+import { getLeaveMessage } from '../../translations';
+import { preventDefault, getDocumentTitle } from '../../utils/helpers';
+import { ADMIN_PREFIX } from '../../constants';
+
+export const compose_creator = WrappedComponent => {
+  class ComposeCreator extends Component {
+    componentDidMount() {
+      const { router, route } = this.props;
+      router.setRouteLeaveHook(route, this.routerWillLeave);
+    }
+
+    componentWillUnmount() {
+      const { clearErrors, errors } = this.props;
+      errors.length && clearErrors();
+    }
+
+    routerWillLeave = nextLocation => {
+      if (this.props.fieldChanged) {
+        return getLeaveMessage();
+      }
+    };
+
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  }
+
+  ComposeCreator.propTypes = {
+    updateTitle: PropTypes.func.isRequired,
+    updateBody: PropTypes.func.isRequired,
+    updatePath: PropTypes.func.isRequired,
+    clearErrors: PropTypes.func.isRequired,
+    errors: PropTypes.array.isRequired,
+    fieldChanged: PropTypes.bool.isRequired,
+    router: PropTypes.object.isRequired,
+    route: PropTypes.object.isRequired,
+    config: PropTypes.object.isRequired,
+  };
+
+  const mapStateToProps = state => ({
+    fieldChanged: state.metadata.fieldChanged,
+    errors: state.utils.errors,
+    config: state.config.config,
+  });
+
+  const mapDispatchToProps = dispatch =>
+    bindActionCreators(
+      {
+        updateTitle,
+        updateBody,
+        updatePath,
+        clearErrors,
+      },
+      dispatch
+    );
+
+  return withRouter(
+    connect(mapStateToProps, mapDispatchToProps)(ComposeCreator)
+  );
+};

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -13,11 +13,8 @@ import { ADMIN_PREFIX } from '../../constants';
 export class DocumentNew extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
-      const path = nextProps.currentDocument.path;
-      const splat = path.substr(path.indexOf('/') + 1, path.length);
-      browserHistory.push(
-        `${ADMIN_PREFIX}/collections/${nextProps.currentDocument.collection}/${splat}`
-      );
+      const { collection, relative_path: path } = nextProps.currentDocument;
+      browserHistory.push(`${ADMIN_PREFIX}/collections/${collection}/${path}`);
     }
   }
 

--- a/src/containers/views/DocumentNew.js
+++ b/src/containers/views/DocumentNew.js
@@ -2,22 +2,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { browserHistory, withRouter } from 'react-router';
+import { browserHistory } from 'react-router';
 import DocumentTitle from 'react-document-title';
 import CreateMarkdownPage from '../../components/CreateMarkdownPage';
-import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { createDocument } from '../../ducks/collections';
-import { clearErrors } from '../../ducks/utils';
-import { getLeaveMessage } from '../../translations';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
+import { compose_creator } from './ComposeCreator';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DocumentNew extends Component {
-  componentDidMount() {
-    const { router, route } = this.props;
-    router.setRouteLeaveHook(route, this.routerWillLeave);
-  }
-
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       const path = nextProps.currentDocument.path;
@@ -28,17 +21,6 @@ export class DocumentNew extends Component {
     }
   }
 
-  componentWillUnmount() {
-    const { clearErrors, errors } = this.props;
-    errors.length && clearErrors();
-  }
-
-  routerWillLeave = nextLocation => {
-    if (this.props.fieldChanged) {
-      return getLeaveMessage();
-    }
-  };
-
   handleClickSave = e => {
     preventDefault(e);
     const { fieldChanged, createDocument, params } = this.props;
@@ -46,32 +28,15 @@ export class DocumentNew extends Component {
   };
 
   render() {
-    const {
-      params,
-      config,
-      errors,
-      updated,
-      updateBody,
-      updatePath,
-      updateTitle,
-      fieldChanged,
-    } = this.props;
-
+    const { params } = this.props;
     const collection = params.collection_name;
     const title = getDocumentTitle(collection, params.splat, 'New document');
 
     return (
       <DocumentTitle title={title}>
         <CreateMarkdownPage
+          {...this.props}
           type={collection}
-          params={params}
-          config={config}
-          errors={errors}
-          updated={updated}
-          updateBody={updateBody}
-          updatePath={updatePath}
-          updateTitle={updateTitle}
-          fieldChanged={fieldChanged}
           onClickSave={this.handleClickSave}
         />
       </DocumentTitle>
@@ -81,40 +46,20 @@ export class DocumentNew extends Component {
 
 DocumentNew.propTypes = {
   createDocument: PropTypes.func.isRequired,
-  updateTitle: PropTypes.func.isRequired,
-  updateBody: PropTypes.func.isRequired,
-  updatePath: PropTypes.func.isRequired,
-  clearErrors: PropTypes.func.isRequired,
-  errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
   updated: PropTypes.bool.isRequired,
   params: PropTypes.object.isRequired,
-  router: PropTypes.object.isRequired,
-  route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
   currentDocument: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
   currentDocument: state.collections.currentDocument,
-  fieldChanged: state.metadata.fieldChanged,
-  errors: state.utils.errors,
   updated: state.collections.updated,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      updateTitle,
-      updateBody,
-      updatePath,
-      createDocument,
-      clearErrors,
-    },
-    dispatch
-  );
+  bindActionCreators({ createDocument }, dispatch);
 
-export default withRouter(
+export default compose_creator(
   connect(mapStateToProps, mapDispatchToProps)(DocumentNew)
 );

--- a/src/containers/views/DraftNew.js
+++ b/src/containers/views/DraftNew.js
@@ -2,22 +2,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { browserHistory, withRouter } from 'react-router';
+import { browserHistory } from 'react-router';
 import DocumentTitle from 'react-document-title';
 import CreateMarkdownPage from '../../components/CreateMarkdownPage';
-import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { putDraft } from '../../ducks/drafts';
-import { clearErrors } from '../../ducks/utils';
-import { getLeaveMessage } from '../../translations';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
+import { compose_creator } from './ComposeCreator';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class DraftNew extends Component {
-  componentDidMount() {
-    const { router, route } = this.props;
-    router.setRouteLeaveHook(route, this.routerWillLeave);
-  }
-
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       browserHistory.push(
@@ -26,17 +19,6 @@ export class DraftNew extends Component {
     }
   }
 
-  componentWillUnmount() {
-    const { clearErrors, errors } = this.props;
-    errors.length && clearErrors();
-  }
-
-  routerWillLeave = nextLocation => {
-    if (this.props.fieldChanged) {
-      return getLeaveMessage();
-    }
-  };
-
   handleClickSave = e => {
     preventDefault(e);
     const { fieldChanged, putDraft, params } = this.props;
@@ -44,31 +26,14 @@ export class DraftNew extends Component {
   };
 
   render() {
-    const {
-      params,
-      config,
-      errors,
-      updated,
-      updateBody,
-      updatePath,
-      updateTitle,
-      fieldChanged,
-    } = this.props;
-
-    const title = getDocumentTitle('drafts', params.splat, 'New draft');
+    const { splat } = this.props.params;
+    const title = getDocumentTitle('drafts', splat, 'New draft');
 
     return (
       <DocumentTitle title={title}>
         <CreateMarkdownPage
+          {...this.props}
           type="drafts"
-          params={params}
-          config={config}
-          errors={errors}
-          updated={updated}
-          updateBody={updateBody}
-          updatePath={updatePath}
-          updateTitle={updateTitle}
-          fieldChanged={fieldChanged}
           onClickSave={this.handleClickSave}
         />
       </DocumentTitle>
@@ -77,41 +42,21 @@ export class DraftNew extends Component {
 }
 
 DraftNew.propTypes = {
-  putDraft: PropTypes.func.isRequired,
-  updateTitle: PropTypes.func.isRequired,
-  updateBody: PropTypes.func.isRequired,
-  updatePath: PropTypes.func.isRequired,
-  clearErrors: PropTypes.func.isRequired,
-  errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
+  putDraft: PropTypes.func.isRequired,
   updated: PropTypes.bool.isRequired,
-  router: PropTypes.object.isRequired,
-  route: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
   draft: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
   draft: state.drafts.draft,
-  fieldChanged: state.metadata.fieldChanged,
-  errors: state.utils.errors,
   updated: state.drafts.updated,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      updateTitle,
-      updateBody,
-      updatePath,
-      putDraft,
-      clearErrors,
-    },
-    dispatch
-  );
+  bindActionCreators({ putDraft }, dispatch);
 
-export default withRouter(
+export default compose_creator(
   connect(mapStateToProps, mapDispatchToProps)(DraftNew)
 );

--- a/src/containers/views/PageNew.js
+++ b/src/containers/views/PageNew.js
@@ -2,38 +2,20 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { browserHistory, withRouter } from 'react-router';
+import { browserHistory } from 'react-router';
 import DocumentTitle from 'react-document-title';
 import CreateMarkdownPage from '../../components/CreateMarkdownPage';
-import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { createPage } from '../../ducks/pages';
-import { clearErrors } from '../../ducks/utils';
-import { getLeaveMessage } from '../../translations';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
+import { compose_creator } from './ComposeCreator';
 import { ADMIN_PREFIX } from '../../constants';
 
 export class PageNew extends Component {
-  componentDidMount() {
-    const { router, route } = this.props;
-    router.setRouteLeaveHook(route, this.routerWillLeave);
-  }
-
   componentWillReceiveProps(nextProps) {
     if (this.props.updated !== nextProps.updated) {
       browserHistory.push(`${ADMIN_PREFIX}/pages/${nextProps.page.path}`);
     }
   }
-
-  componentWillUnmount() {
-    const { clearErrors, errors } = this.props;
-    errors.length && clearErrors();
-  }
-
-  routerWillLeave = nextLocation => {
-    if (this.props.fieldChanged) {
-      return getLeaveMessage();
-    }
-  };
 
   handleClickSave = e => {
     preventDefault(e);
@@ -42,31 +24,14 @@ export class PageNew extends Component {
   };
 
   render() {
-    const {
-      params,
-      config,
-      errors,
-      updated,
-      updateBody,
-      updatePath,
-      updateTitle,
-      fieldChanged,
-    } = this.props;
-
-    const title = getDocumentTitle('pages', params.splat, 'New page');
+    const { splat } = this.props.params;
+    const title = getDocumentTitle('pages', splat, 'New page');
 
     return (
       <DocumentTitle title={title}>
         <CreateMarkdownPage
+          {...this.props}
           type="pages"
-          params={params}
-          config={config}
-          errors={errors}
-          updated={updated}
-          updateBody={updateBody}
-          updatePath={updatePath}
-          updateTitle={updateTitle}
-          fieldChanged={fieldChanged}
           onClickSave={this.handleClickSave}
         />
       </DocumentTitle>
@@ -75,41 +40,21 @@ export class PageNew extends Component {
 }
 
 PageNew.propTypes = {
-  createPage: PropTypes.func.isRequired,
-  updateTitle: PropTypes.func.isRequired,
-  updateBody: PropTypes.func.isRequired,
-  updatePath: PropTypes.func.isRequired,
-  clearErrors: PropTypes.func.isRequired,
-  errors: PropTypes.array.isRequired,
   fieldChanged: PropTypes.bool.isRequired,
+  createPage: PropTypes.func.isRequired,
   updated: PropTypes.bool.isRequired,
-  router: PropTypes.object.isRequired,
-  route: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
   page: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
   page: state.pages.page,
-  fieldChanged: state.metadata.fieldChanged,
-  errors: state.utils.errors,
   updated: state.pages.updated,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      updateTitle,
-      updateBody,
-      updatePath,
-      createPage,
-      clearErrors,
-    },
-    dispatch
-  );
+  bindActionCreators({ createPage }, dispatch);
 
-export default withRouter(
+export default compose_creator(
   connect(mapStateToProps, mapDispatchToProps)(PageNew)
 );


### PR DESCRIPTION
Reduces the repeated logic across `DocumentNew`, `DraftNew`, `PageNew`