### PR TITLE
Prefer ES6 object-properties-shorthand syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "no-unused-vars": 0,
     "no-debugger": 1,
     "no-var": 1,
+    "object-shorthand": [1, "properties"],
     "semi": [1, "always"],
     "no-trailing-spaces": 0,
     "eol-last": 0,

--- a/src/components/form/tests/inputpath.spec.js
+++ b/src/components/form/tests/inputpath.spec.js
@@ -17,9 +17,9 @@ function setup(defaultProps = props) {
   let component = mount(<InputPath {...defaultProps} {...actions} />);
 
   return {
-    component: component,
-    input: component.find('textarea'),
     actions,
+    component,
+    input: component.find('textarea'),
   };
 }
 

--- a/src/components/tests/editor.spec.js
+++ b/src/components/tests/editor.spec.js
@@ -13,9 +13,9 @@ function setup(props = { content, editorChanged: false }) {
   let component = shallow(<Editor {...props} {...actions} />);
 
   return {
+    actions,
     component,
     editor: component.find('.config-editor'),
-    actions: actions,
   };
 }
 

--- a/src/components/tests/explorer.spec.js
+++ b/src/components/tests/explorer.spec.js
@@ -23,8 +23,8 @@ function setup(overrides = {}) {
   );
 
   return {
-    component: component,
-    actions: actions,
+    component,
+    actions,
     header: component.find('.content-header'),
   };
 }

--- a/src/components/tests/filepreview.spec.js
+++ b/src/components/tests/filepreview.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import FilePreview from '../FilePreview';
-
 import { staticfile } from './fixtures';
 
 function setup(file = staticfile) {
@@ -14,13 +13,13 @@ function setup(file = staticfile) {
   let component = mount(<FilePreview file={file} splat="" {...actions} />);
 
   return {
+    actions,
     component,
     filename: component.find('.filename'),
     image: component.find('img'),
     div: component.find('.file-preview a div'),
     indicator: component.find('.file-preview .theme-indicator'),
     delete_btn: component.find('.file-preview .delete'),
-    actions: actions,
   };
 }
 

--- a/src/containers/tests/metafields.spec.js
+++ b/src/containers/tests/metafields.spec.js
@@ -25,11 +25,11 @@ function setup(props = defaultProps) {
   const component = mount(<MetaFields {...props} {...actions} />);
 
   return {
+    actions,
     component,
     addFieldButton: component.find('.meta-new a'),
     addDataFieldButton: component.find('.data-new a'),
     metafields: component.find(MetaField),
-    actions: actions,
   };
 }
 

--- a/src/containers/tests/sidebar.spec.js
+++ b/src/containers/tests/sidebar.spec.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
-import { Sidebar } from '../Sidebar';
 
+import { Sidebar } from '../Sidebar';
 import { collections, config } from './fixtures';
 
 const defaultProps = {

--- a/src/containers/views/tests/configuration.spec.js
+++ b/src/containers/views/tests/configuration.spec.js
@@ -25,9 +25,9 @@ const setup = (props = defaultProps) => {
 
   const component = shallow(<Configuration {...props} {...actions} />);
   return {
-    component,
     props,
     actions,
+    component,
     editor: component.find(Editor),
     errors: component.find(Errors),
     toggleButton: component.find(Button).first(),

--- a/src/containers/views/tests/datafileedit.spec.js
+++ b/src/containers/views/tests/datafileedit.spec.js
@@ -7,7 +7,7 @@ import Button from '../../../components/Button';
 import { datafile } from './fixtures';
 
 const defaultProps = {
-  datafile: datafile,
+  datafile,
   updated: false,
   datafileChanged: false,
   fieldChanged: false,
@@ -30,13 +30,13 @@ const setup = (props = defaultProps) => {
   const component = shallow(<DataFileEdit {...actions} {...props} />);
 
   return {
-    component,
+    props,
     actions,
+    component,
     saveButton: component.find(Button).first(),
     toggleButton: component.find(Button).at(1),
     deleteButton: component.find(Button).last(),
     errors: component.find(Errors),
-    props,
   };
 };
 

--- a/src/containers/views/tests/datafilenew.spec.js
+++ b/src/containers/views/tests/datafilenew.spec.js
@@ -27,14 +27,14 @@ const setup = (props = defaultProps) => {
   const component = shallow(<DataFileNew {...actions} {...props} />);
 
   return {
-    component,
+    props,
     actions,
+    component,
     saveButton: component.find(Button).first(),
     toggleButton: component.find(Button).last(),
     editor: component.find(Editor).first(),
     gui: component.find(DataGUI).first(),
     errors: component.find(Errors),
-    props,
   };
 };
 

--- a/src/containers/views/tests/datafiles.spec.js
+++ b/src/containers/views/tests/datafiles.spec.js
@@ -20,8 +20,8 @@ function setup(datafiles = [directory, datafile]) {
   const component = mount(<DataFiles {...props} {...actions} />);
 
   return {
+    actions,
     component,
-    actions: actions,
     h1: component.find('h1').last(),
     breadcrumbs: component.find('.breadcrumbs'),
     table: component.find('.content-table'),

--- a/src/containers/views/tests/documentedit.spec.js
+++ b/src/containers/views/tests/documentedit.spec.js
@@ -8,6 +8,7 @@ import Button from '../../../components/Button';
 import { config, doc } from './fixtures';
 
 const defaultProps = {
+  config,
   currentDocument: doc,
   errors: [],
   fieldChanged: false,
@@ -15,7 +16,6 @@ const defaultProps = {
   isFetching: false,
   router: {},
   route: {},
-  config: config,
   params: { collection_name: 'movies', splat: [null, 'inception', 'md'] },
 };
 
@@ -33,12 +33,12 @@ const setup = (props = defaultProps) => {
   const component = shallow(<DocumentEdit {...actions} {...props} />);
 
   return {
-    component,
+    props,
     actions,
+    component,
     saveButton: component.find(Button).first(),
     deleteButton: component.find(Button).last(),
     errors: component.find(Errors),
-    props,
   };
 };
 

--- a/src/containers/views/tests/documents.spec.js
+++ b/src/containers/views/tests/documents.spec.js
@@ -20,8 +20,8 @@ function setup(documents = [directory, doc]) {
   const component = mount(<Documents {...actions} {...props} />);
 
   return {
-    component: component,
-    actions: actions,
+    actions,
+    component,
     h1: component.find('h1').last(),
     breadcrumbs: component.find('.breadcrumbs'),
     new_button: component.find('.page-buttons a').first(),

--- a/src/containers/views/tests/drafts.spec.js
+++ b/src/containers/views/tests/drafts.spec.js
@@ -20,8 +20,8 @@ function setup(drafts = [directory, draft]) {
   const component = mount(<Drafts {...props} {...actions} />);
 
   return {
-    component: component,
-    actions: actions,
+    actions,
+    component,
     h1: component.find('h1').last(),
     breadcrumbs: component.find('.breadcrumbs'),
     table: component.find('.content-table'),

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -8,14 +8,14 @@ import Button from '../../../components/Button';
 import { config, page } from './fixtures';
 
 const defaultProps = {
-  page: page,
+  page,
+  config,
   errors: [],
   fieldChanged: false,
   updated: false,
   isFetching: false,
   router: {},
   route: {},
-  config: config,
   params: { splat: [null, 'page', 'md'] },
 };
 
@@ -33,12 +33,12 @@ const setup = (props = defaultProps) => {
   const component = shallow(<PageEdit {...actions} {...props} />);
 
   return {
-    component,
+    props,
     actions,
+    component,
     saveButton: component.find(Button).first(),
     deleteButton: component.find(Button).last(),
     errors: component.find(Errors),
-    props,
   };
 };
 

--- a/src/containers/views/tests/pages.spec.js
+++ b/src/containers/views/tests/pages.spec.js
@@ -20,8 +20,8 @@ function setup(pages = [directory, page]) {
   const component = mount(<Pages {...props} {...actions} />);
 
   return {
-    component: component,
-    actions: actions,
+    actions,
+    component,
     h1: component.find('h1').last(),
     breadcrumbs: component.find('.breadcrumbs'),
     table: component.find('.content-table'),

--- a/src/containers/views/tests/staticfiles.spec.js
+++ b/src/containers/views/tests/staticfiles.spec.js
@@ -21,8 +21,8 @@ function setup(files = [directory, staticfile]) {
   const component = mount(<StaticFiles {...props} {...actions} />);
 
   return {
-    component: component,
-    actions: actions,
+    actions,
+    component,
     info: component.find('.preview-info'),
     previewContainer: component.find('.preview-container'),
   };

--- a/src/containers/views/tests/staticindex.spec.js
+++ b/src/containers/views/tests/staticindex.spec.js
@@ -20,8 +20,8 @@ function setup(files = [staticfile]) {
   const component = mount(<StaticIndex {...props} {...actions} />);
 
   return {
-    component: component,
-    actions: actions,
+    actions,
+    component,
     info: component.find('.preview-info'),
     previewContainer: component.find('.preview-container'),
   };


### PR DESCRIPTION
Replace `{ 'foo': foo, 'bar': bar }` and `{ foo: foo, bar: bar }` with terser `{ foo, bar }`