### PR TITLE
Enforce unix-style line-endings for *.js files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     "no-debugger": 1,
     "no-var": 1,
     "object-shorthand": [1, "properties"],
+    "linebreak-style": [1, "unix"],
     "semi": [1, "always"],
     "no-trailing-spaces": 0,
     "eol-last": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,6 @@
     "no-debugger": 1,
     "no-var": 1,
     "object-shorthand": [1, "properties"],
-    "linebreak-style": [1, "unix"],
     "semi": [1, "always"],
     "no-trailing-spaces": 0,
     "eol-last": 0,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --single-quote --trailing-comma --print-width 80 es5 --write"
+      "prettier --single-quote --trailing-comma --end-of-line lf --print-width 80 es5 --write"
     ]
   },
   "author": "Mert Kahyaoğlu",


### PR DESCRIPTION
So that bundle's sourcemap doesn't include `\r\n` when built on Windows