### PR TITLE
Enable ESLint rule `eqeqeq`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
   "rules": {
     "import/no-named-as-default": 0,
     "quotes": 0,
+    "eqeqeq": 1,
     "no-console": 1,
     "no-unused-vars": [1, { "args": "none" }],
     "no-debugger": 1,

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -11,9 +11,9 @@ export default function Breadcrumbs({ type, splat = '' }) {
     : `${ADMIN_PREFIX}/collections/${type}`;
 
   let label = type;
-  if (type == 'datafiles') {
+  if (type === 'datafiles') {
     label = 'data files';
-  } else if (type == 'staticfiles') {
+  } else if (type === 'staticfiles') {
     label = 'static files';
   }
 
@@ -21,7 +21,7 @@ export default function Breadcrumbs({ type, splat = '' }) {
   if (splat) {
     const paths = splat.split('/');
     nodes = paths.map((path, i) => {
-      const before = i == 0 ? '' : paths.slice(0, i).join('/') + '/';
+      const before = i === 0 ? '' : paths.slice(0, i).join('/') + '/';
       return (
         <li key={i}>
           <Link to={`${base}/${before}${path}`}>{path}</Link>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -27,9 +27,9 @@ export default function Button({
 }) {
   const btnClass = classnames('btn', {
     'btn-active': active,
-    'btn-success': active && (type == 'save' || type == 'create'),
-    'btn-delete': type == 'delete',
-    'btn-view': type == 'view' || type == 'publish',
+    'btn-success': active && (type === 'save' || type === 'create'),
+    'btn-delete': type === 'delete',
+    'btn-view': type === 'view' || type === 'publish',
     'btn-inactive': !active,
     'btn-fat': block,
     'btn-thin': thin,

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -67,7 +67,7 @@ export default class Explorer extends Component {
   renderRows() {
     const { items, type } = this.props;
     return items.map((entry, index) =>
-      entry.type == 'directory'
+      entry.type === 'directory'
         ? this.renderDirectoryRow(entry, type, index)
         : this.renderFileRow(entry, type, index)
     );

--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -21,7 +21,7 @@ export default class FilePreview extends Component {
           <Icon name="diamond" />
         </span>
       );
-    } else if (splat != 'index') {
+    } else if (splat !== 'index') {
       return (
         <button
           onClick={() => this.handleClickDelete(file.relative_path)}

--- a/src/components/form/InputPath.js
+++ b/src/components/form/InputPath.js
@@ -21,15 +21,15 @@ export default class InputFilename extends Component {
     const { path, type } = this.props;
 
     let placeholder = 'example.md';
-    if (type == 'posts') {
+    if (type === 'posts') {
       const date = moment().format('YYYY-MM-DD');
       placeholder = `${date}-your-title.md`;
-    } else if (type == 'data files') {
+    } else if (type === 'data files') {
       placeholder = 'your-filename.yml';
     }
 
     let tooltip = null;
-    if (type != 'data files') {
+    if (type !== 'data files') {
       tooltip = (
         <span className="tooltip">
           <Icon name="info-circle" />

--- a/src/components/form/InputSearch.js
+++ b/src/components/form/InputSearch.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export default class InputSearch extends Component {
   handleKeyPress = event => {
     const { search } = this.props;
-    if (event.charCode == 13) {
+    if (event.charCode === 13) {
       search(event.target.value);
     }
   };

--- a/src/components/metadata/MetaButtons.js
+++ b/src/components/metadata/MetaButtons.js
@@ -61,7 +61,7 @@ export default class MetaButtons extends Component {
 
     return (
       <div className="meta-buttons">
-        {parentType == 'array' && sortableHandle}
+        {parentType === 'array' && sortableHandle}
         <span className={dropdownClasses}>
           <a
             className="meta-button"

--- a/src/components/metadata/MetaField.js
+++ b/src/components/metadata/MetaField.js
@@ -20,7 +20,7 @@ export class MetaField extends Component {
   handleKeyBlur() {
     const { namePrefix, fieldKey, updateFieldKey } = this.props;
     let currentValue = findDOMNode(this.refs.field_key).value;
-    if (fieldKey != currentValue && currentValue != '') {
+    if (fieldKey !== currentValue && currentValue !== '') {
       updateFieldKey(namePrefix, fieldKey, currentValue);
     }
   }

--- a/src/components/metadata/MetaObjectItem.js
+++ b/src/components/metadata/MetaObjectItem.js
@@ -15,7 +15,7 @@ export class MetaObjectItem extends Component {
   handleKeyBlur() {
     const { namePrefix, fieldKey, updateFieldKey } = this.props;
     let currentValue = findDOMNode(this.refs.field_key).value;
-    if (fieldKey != currentValue && currentValue != '') {
+    if (fieldKey !== currentValue && currentValue !== '') {
       updateFieldKey(namePrefix, fieldKey, currentValue);
     }
   }

--- a/src/components/metadata/MetaSimple.js
+++ b/src/components/metadata/MetaSimple.js
@@ -41,7 +41,7 @@ export class MetaSimple extends Component {
   renderDatepicker() {
     const { fieldValue } = this.props;
     let dateValue =
-      new Date(fieldValue) == 'Invalid Date' ? null : new Date(fieldValue);
+      new Date(fieldValue) === 'Invalid Date' ? null : new Date(fieldValue);
     return (
       <DateTimePicker
         onChange={this.handleDatepickerChange}

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -28,7 +28,7 @@ export class Sidebar extends Component {
     }
 
     const collectionItems = _.map(collections, (col, i) => {
-      if (col.label != 'posts' && !hiddens.includes(col.label)) {
+      if (col.label !== 'posts' && !hiddens.includes(col.label)) {
         return (
           <li key={i}>
             <Link

--- a/src/containers/views/DataFileEdit.js
+++ b/src/containers/views/DataFileEdit.js
@@ -50,7 +50,7 @@ export class DataFileEdit extends Component {
       const path = this.props.datafile.path;
 
       // redirect if the path is changed
-      if (new_path != path) {
+      if (new_path !== path) {
         browserHistory.push(
           `${ADMIN_PREFIX}/datafiles/${nextProps.datafile.relative_path}`
         );
@@ -108,7 +108,7 @@ export class DataFileEdit extends Component {
         ? data_dir + `${directory}/` + name
         : data_dir + name;
 
-      const new_path = data_path != path ? data_path : '';
+      const new_path = data_path !== path ? data_path : '';
       putDataFile(directory, filename, data, new_path, mode);
     }
   };

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -44,7 +44,7 @@ export class DocumentEdit extends Component {
       const new_path = nextProps.currentDocument.path;
       const path = currentDocument.path;
       // redirect if the path is changed
-      if (new_path != path) {
+      if (new_path !== path) {
         browserHistory.push(
           `${ADMIN_PREFIX}/collections/${new_path.substring(1)}` // remove `_`
         );

--- a/src/containers/views/Documents.js
+++ b/src/containers/views/Documents.js
@@ -68,7 +68,7 @@ export class Documents extends Component {
     // date w/o timezone
     let date = doc.date.substring(0, doc.date.lastIndexOf(' '));
     date =
-      moment(date).format('hh:mm:ss') == '12:00:00'
+      moment(date).format('hh:mm:ss') === '12:00:00'
         ? moment(date).format('ll')
         : moment(date).format('lll');
 
@@ -124,7 +124,7 @@ export class Documents extends Component {
   renderRows() {
     const { documents } = this.props;
     return _.map(documents, entry => {
-      if (entry.type && entry.type == 'directory') {
+      if (entry.type && entry.type === 'directory') {
         return this.renderDirectoryRow(entry);
       } else {
         return this.renderFileRow(entry);
@@ -154,7 +154,7 @@ export class Documents extends Component {
             <Breadcrumbs type={collection_name} splat={splat} />
             <div className="page-buttons">
               <Link className="btn btn-active" to={to}>
-                {collection_name == 'posts' ? 'New post' : 'New document'}
+                {collection_name === 'posts' ? 'New post' : 'New document'}
               </Link>
             </div>
             <div className="pull-right">

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -50,7 +50,7 @@ export class DraftEdit extends Component {
       const new_path = nextProps.draft.path;
       const path = this.props.draft.path;
       // redirect if the path is changed
-      if (new_path != path) {
+      if (new_path !== path) {
         browserHistory.push(
           `${ADMIN_PREFIX}/drafts/${nextProps.draft.relative_path}`
         );

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -40,7 +40,7 @@ export class PageEdit extends Component {
       const new_path = nextProps.page.path;
       const path = this.props.page.path;
       // redirect if the path is changed
-      if (new_path != path) {
+      if (new_path !== path) {
         browserHistory.push(`${ADMIN_PREFIX}/pages/${new_path}`);
       }
     }

--- a/src/containers/views/StaticFiles.js
+++ b/src/containers/views/StaticFiles.js
@@ -93,7 +93,7 @@ export class StaticFiles extends Component {
 
   renderRows() {
     const { files } = this.props;
-    const dirs = files.filter(entity => entity.type == 'directory');
+    const dirs = files.filter(entity => entity.type === 'directory');
     const static_files = files.filter(entity => !entity.type);
 
     return dirs

--- a/src/ducks/collections.js
+++ b/src/ducks/collections.js
@@ -80,7 +80,7 @@ export const createDocument = (collection, directory) => (
   const metadata = getState().metadata.metadata;
   let { path, raw_content, title } = metadata;
   // if path is not given or equals to directory, generate filename from the title
-  if ((!path || `${path}/` == directory) && title) {
+  if ((!path || `${path}/` === directory) && title) {
     path = generateFilenameFromTitle(metadata, collection); // override empty path
   } else {
     // validate otherwise
@@ -93,7 +93,7 @@ export const createDocument = (collection, directory) => (
   dispatch({ type: CLEAR_ERRORS });
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value == '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
   // send the put request
   return put(
@@ -114,7 +114,7 @@ export const putDocument = (collection, directory, filename) => (
   const metadata = getState().metadata.metadata;
   let { path, raw_content, title } = metadata;
   // if path is not given or equals to directory, generate filename from the title
-  if ((!path || `${path}/` == directory) && title) {
+  if ((!path || `${path}/` === directory) && title) {
     path = generateFilenameFromTitle(metadata, collection); // override empty path
   } else {
     // validate otherwise
@@ -127,7 +127,7 @@ export const putDocument = (collection, directory, filename) => (
   dispatch({ type: CLEAR_ERRORS });
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value == '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
   // add collection type prefix to relative path
   const relative_path = directory
@@ -162,7 +162,7 @@ export const deleteDocument = (collection, directory, filename) => dispatch => {
 };
 
 const generateFilenameFromTitle = (metadata, collection) => {
-  if (collection == 'posts') {
+  if (collection === 'posts') {
     // if date is provided, use it, otherwise generate it with today's date
     let date;
     if (metadata.date) {
@@ -183,7 +183,7 @@ const validateDocument = (metadata, collection) => {
     'path.required': getFilenameRequiredMessage(),
   };
 
-  if (collection == 'posts') {
+  if (collection === 'posts') {
     validations['path'] = 'required|date';
     messages['path.date'] = getFilenameNotValidMessage();
   } else {

--- a/src/ducks/config.js
+++ b/src/ducks/config.js
@@ -33,7 +33,7 @@ export const putConfig = (config, source = 'editor') => (
 ) => {
   let payload;
 
-  if (source == 'gui') {
+  if (source === 'gui') {
     config = getState().metadata.metadata;
     payload = { raw_content: toYAML(config) };
   } else {

--- a/src/ducks/datafiles.js
+++ b/src/ducks/datafiles.js
@@ -61,7 +61,7 @@ export const putDataFile = (
 ) => (dispatch, getState) => {
   const ext = getExtensionFromPath(new_path || filename);
 
-  if (source == 'gui') {
+  if (source === 'gui') {
     const json = /json/i.test(ext);
     let metadata = getState().metadata.metadata;
     metadata = trimObject(metadata);

--- a/src/ducks/drafts.js
+++ b/src/ducks/drafts.js
@@ -64,11 +64,11 @@ export const putDraft = (mode, directory, filename = '') => (
 
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value === '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
 
   let payload;
-  if (mode == 'create') {
+  if (mode === 'create') {
     // strip '_drafts/' from path when provided
     filename = path.replace('_drafts/', '');
     payload = { front_matter, raw_content };
@@ -112,7 +112,7 @@ export const publishDraft = (directory, filename) => (dispatch, getState) => {
 
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value == '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
 
   return put(

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -60,7 +60,7 @@ export const createPage = directory => (dispatch, getState) => {
   dispatch({ type: CLEAR_ERRORS });
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value === '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
   //send the put request
   return put(
@@ -89,7 +89,7 @@ export const putPage = (directory, filename) => (dispatch, getState) => {
   dispatch({ type: CLEAR_ERRORS });
   // omit raw_content, path and empty-value keys in metadata state from front_matter
   const front_matter = _.omit(metadata, (value, key, object) => {
-    return key == 'raw_content' || key == 'path' || value === '';
+    return key === 'raw_content' || key === 'path' || value === '';
   });
   const relative_path = directory ? `${directory}/${path}` : `${path}`;
   //send the put request

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -129,7 +129,7 @@ export const preventDefault = event => {
 export const trimObject = object => {
   if (!_.isObject(object)) return object;
   return _.keys(object).reduce((acc, key) => {
-    if (typeof object[key] == 'string') {
+    if (typeof object[key] === 'string') {
       try {
         acc[key.trim()] = JSON.parse(object[key].trim());
       } catch (e) {

--- a/src/utils/metadata.js
+++ b/src/utils/metadata.js
@@ -59,7 +59,7 @@ export const updateMetadataFieldKey = (state, namePrefix, fieldKey, newKey) => {
   if (field === undefined) return tmpState.metadata;
   if (_.has(field, newKey)) return tmpState.metadata;
   field = Object.keys(field).reduce((result, current) => {
-    if (current == fieldKey) result[newKey] = field[current];
+    if (current === fieldKey) result[newKey] = field[current];
     else result[current] = field[current];
     return result;
   }, {});
@@ -94,8 +94,8 @@ export const convertMetadataField = (state, nameAttr, convertType) => {
   let tmpState = cloneDeep(state);
   let field = eval(`tmpState.${nameAttr}`);
   if (field === undefined) return tmpState.metadata;
-  if (convertType == 'array') field = [''];
-  else if (convertType == 'object') {
+  if (convertType === 'array') field = [''];
+  else if (convertType === 'object') {
     let key = `New field ${state.new_field_count}`;
     field = { [key]: '' };
   } else field = '';
@@ -141,8 +141,8 @@ export const injectDefaultFields = (config, path, type, front_matter = {}) => {
   _.each(defaults, field => {
     const scope = field.scope;
     if (
-      (!scope.type || scope.type == type) &&
-      (!scope.path || scope.path == path)
+      (!scope.type || scope.type === type) &&
+      (!scope.path || scope.path === path)
     ) {
       _.extend(metafields, field.values);
     }


### PR DESCRIPTION
To enforce use of the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`