### PR TITLE
Use Yarn to manage dependencies on CI

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,4 +4,4 @@ set -e
 
 script/branding
 bundle install
-npm install
+yarn install


### PR DESCRIPTION
Since we already check-in `yarn.lock` to the repository, it would be better if CI builds used the same set.