### PR TITLE
Use fetch wrapper for DELETE requests to dispatch

### DIFF
--- a/src/ducks/action_tests/collections.spec.js
+++ b/src/ducks/action_tests/collections.spec.js
@@ -87,8 +87,7 @@ describe('Actions::Collections', () => {
       .reply(200);
 
     const expectedActions = [
-      { type: collectionsDuck.DELETE_DOCUMENT_SUCCESS },
-      { type: collectionsDuck.FETCH_COLLECTION_REQUEST },
+      { type: collectionsDuck.DELETE_DOCUMENT_SUCCESS, id: filename },
     ];
 
     const store = mockStore({});

--- a/src/ducks/action_tests/datafiles.spec.js
+++ b/src/ducks/action_tests/datafiles.spec.js
@@ -249,8 +249,7 @@ describe('Actions::Datafiles', () => {
       .reply(200);
 
     const expectedAction = [
-      { type: datafilesDuck.DELETE_DATAFILE_SUCCESS },
-      { type: datafilesDuck.FETCH_DATAFILES_REQUEST },
+      { type: datafilesDuck.DELETE_DATAFILE_SUCCESS, id: 'data_file.yml' },
     ];
 
     const store = mockStore({ files: [] });

--- a/src/ducks/action_tests/drafts.spec.js
+++ b/src/ducks/action_tests/drafts.spec.js
@@ -57,8 +57,7 @@ describe('Actions::Drafts', () => {
       .reply(200);
 
     const expectedActions = [
-      { type: draftsDuck.DELETE_DRAFT_SUCCESS },
-      { type: draftsDuck.FETCH_DRAFTS_REQUEST },
+      { type: draftsDuck.DELETE_DRAFT_SUCCESS, id: 'draft-dir/test.md' },
     ];
 
     const store = mockStore({});

--- a/src/ducks/action_tests/pages.spec.js
+++ b/src/ducks/action_tests/pages.spec.js
@@ -51,12 +51,11 @@ describe('Actions::Pages', () => {
 
   it('deletes the page successfully', () => {
     nock(API)
-      .delete(`/pages/page-dir/test/test.md`)
+      .delete('/pages/page-dir/test/test.md')
       .reply(200);
 
     const expectedActions = [
-      { type: pagesDuck.DELETE_PAGE_SUCCESS },
-      { type: pagesDuck.FETCH_PAGES_REQUEST },
+      { type: pagesDuck.DELETE_PAGE_SUCCESS, id: 'page-dir/test/test.md' },
     ];
 
     const store = mockStore({});
@@ -70,7 +69,7 @@ describe('Actions::Pages', () => {
 
   it('creates DELETE_PAGE_FAILURE when deleting a page failed', () => {
     nock(API)
-      .delete(`/pages/page.md`)
+      .delete('/pages/page.md')
       .replyWithError('something awful happened');
 
     const expectedAction = {

--- a/src/ducks/action_tests/staticfiles.spec.js
+++ b/src/ducks/action_tests/staticfiles.spec.js
@@ -95,8 +95,7 @@ describe('Actions::StaticFiles', () => {
       .reply(200);
 
     const expectedActions = [
-      { type: staticfilesDuck.DELETE_STATICFILE_SUCCESS },
-      { type: staticfilesDuck.FETCH_STATICFILES_REQUEST },
+      { type: staticfilesDuck.DELETE_STATICFILE_SUCCESS, id: 'index.html' },
     ];
 
     const store = mockStore({ files: [] });

--- a/src/ducks/collections.js
+++ b/src/ducks/collections.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { CLEAR_ERRORS, validationError } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
-import { slugify, trimObject } from '../utils/helpers';
+import { slugify, trimObject, computeRelativePath } from '../utils/helpers';
 import {
   collectionsAPIUrl,
   collectionAPIUrl,
@@ -145,13 +145,10 @@ export const putDocument = (collection, directory, filename) => (
 };
 
 export const deleteDocument = (collection, directory, filename) => dispatch => {
+  const relative_path = computeRelativePath(directory, filename);
   return del(
     documentAPIUrl(collection, directory, filename),
-    {
-      type: DELETE_DOCUMENT_SUCCESS,
-      name: 'doc',
-      update: fetchCollection(collection, directory),
-    },
+    { type: DELETE_DOCUMENT_SUCCESS, name: 'doc', id: relative_path },
     { type: DELETE_DOCUMENT_FAILURE, name: 'error' },
     dispatch
   );
@@ -251,6 +248,11 @@ export default function collections(
         ...state,
         currentDocument: action.doc,
         updated: true,
+      };
+    case DELETE_DOCUMENT_SUCCESS:
+      return {
+        ...state,
+        entries: state.entries.filter(doc => doc.relative_path !== action.id),
       };
     default:
       return {

--- a/src/ducks/collections.js
+++ b/src/ducks/collections.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import moment from 'moment';
-import { CLEAR_ERRORS, validationError } from './utils';
+import { CLEAR_ERRORS, validationError, filterDeleted } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject, computeRelativePath } from '../utils/helpers';
@@ -252,7 +252,7 @@ export default function collections(
     case DELETE_DOCUMENT_SUCCESS:
       return {
         ...state,
-        entries: state.entries.filter(doc => doc.relative_path !== action.id),
+        entries: filterDeleted(state.entries, action.id),
       };
     default:
       return {

--- a/src/ducks/collections.js
+++ b/src/ducks/collections.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import moment from 'moment';
 import { CLEAR_ERRORS, validationError } from './utils';
-import { get, put } from '../utils/fetch';
+import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject } from '../utils/helpers';
 import {
@@ -145,20 +145,16 @@ export const putDocument = (collection, directory, filename) => (
 };
 
 export const deleteDocument = (collection, directory, filename) => dispatch => {
-  return fetch(documentAPIUrl(collection, directory, filename), {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-    .then(data => {
-      dispatch({ type: DELETE_DOCUMENT_SUCCESS });
-      dispatch(fetchCollection(collection, directory));
-    })
-    .catch(error =>
-      dispatch({
-        type: DELETE_DOCUMENT_FAILURE,
-        error,
-      })
-    );
+  return del(
+    documentAPIUrl(collection, directory, filename),
+    {
+      type: DELETE_DOCUMENT_SUCCESS,
+      name: 'doc',
+      update: fetchCollection(collection, directory),
+    },
+    { type: DELETE_DOCUMENT_FAILURE, name: 'error' },
+    dispatch
+  );
 };
 
 const generateFilenameFromTitle = (metadata, collection) => {

--- a/src/ducks/datafiles.js
+++ b/src/ducks/datafiles.js
@@ -1,7 +1,12 @@
 import { CLEAR_ERRORS, validationError } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { datafilesAPIUrl, datafileAPIUrl } from '../constants/api';
-import { toYAML, getExtensionFromPath, trimObject } from '../utils/helpers';
+import {
+  toYAML,
+  trimObject,
+  computeRelativePath,
+  getExtensionFromPath,
+} from '../utils/helpers';
 import { validator } from '../utils/validation';
 
 import translations from '../translations';
@@ -89,13 +94,10 @@ export const putDataFile = (
 };
 
 export const deleteDataFile = (directory, filename) => dispatch => {
+  const relative_path = computeRelativePath(directory, filename);
   return del(
     datafileAPIUrl(directory, filename),
-    {
-      type: DELETE_DATAFILE_SUCCESS,
-      name: 'file',
-      update: fetchDataFiles(directory),
-    },
+    { type: DELETE_DATAFILE_SUCCESS, name: 'file', id: relative_path },
     { type: DELETE_DATAFILE_FAILURE, name: 'error' },
     dispatch
   );
@@ -170,6 +172,11 @@ export default function datafiles(
       return {
         ...state,
         datafileChanged: false,
+      };
+    case DELETE_DATAFILE_SUCCESS:
+      return {
+        ...state,
+        files: state.files.filter(f => f.relative_path !== action.id),
       };
     case DATAFILE_CHANGED:
       return {

--- a/src/ducks/datafiles.js
+++ b/src/ducks/datafiles.js
@@ -1,5 +1,5 @@
 import { CLEAR_ERRORS, validationError } from './utils';
-import { get, put } from '../utils/fetch';
+import { get, put, del } from '../utils/fetch';
 import { datafilesAPIUrl, datafileAPIUrl } from '../constants/api';
 import { toYAML, getExtensionFromPath, trimObject } from '../utils/helpers';
 import { validator } from '../utils/validation';
@@ -89,20 +89,16 @@ export const putDataFile = (
 };
 
 export const deleteDataFile = (directory, filename) => dispatch => {
-  return fetch(datafileAPIUrl(directory, filename), {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-    .then(data => {
-      dispatch({ type: DELETE_DATAFILE_SUCCESS });
-      dispatch(fetchDataFiles(directory));
-    })
-    .catch(error =>
-      dispatch({
-        type: DELETE_DATAFILE_FAILURE,
-        error,
-      })
-    );
+  return del(
+    datafileAPIUrl(directory, filename),
+    {
+      type: DELETE_DATAFILE_SUCCESS,
+      name: 'file',
+      update: fetchDataFiles(directory),
+    },
+    { type: DELETE_DATAFILE_FAILURE, name: 'error' },
+    dispatch
+  );
 };
 
 export const onDataFileChanged = () => ({

--- a/src/ducks/datafiles.js
+++ b/src/ducks/datafiles.js
@@ -1,4 +1,4 @@
-import { CLEAR_ERRORS, validationError } from './utils';
+import { CLEAR_ERRORS, validationError, filterDeleted } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { datafilesAPIUrl, datafileAPIUrl } from '../constants/api';
 import {
@@ -176,7 +176,7 @@ export default function datafiles(
     case DELETE_DATAFILE_SUCCESS:
       return {
         ...state,
-        files: state.files.filter(f => f.relative_path !== action.id),
+        files: filterDeleted(state.files, action.id),
       };
     case DATAFILE_CHANGED:
       return {

--- a/src/ducks/drafts.js
+++ b/src/ducks/drafts.js
@@ -1,7 +1,7 @@
 import _ from 'underscore';
 import { CLEAR_ERRORS, validationError } from './utils';
 import { PUT_DOCUMENT_SUCCESS, PUT_DOCUMENT_FAILURE } from './collections';
-import { get, put } from '../utils/fetch';
+import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject } from '../utils/helpers';
 import { draftsAPIUrl, draftAPIUrl, documentAPIUrl } from '../constants/api';
@@ -90,20 +90,16 @@ export const putDraft = (mode, directory, filename = '') => (
 };
 
 export const deleteDraft = (directory, filename) => dispatch => {
-  return fetch(draftAPIUrl(directory, filename), {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-    .then(data => {
-      dispatch({ type: DELETE_DRAFT_SUCCESS });
-      dispatch(fetchDrafts(directory));
-    })
-    .catch(error =>
-      dispatch({
-        type: DELETE_DRAFT_FAILURE,
-        error,
-      })
-    );
+  return del(
+    draftAPIUrl(directory, filename),
+    {
+      type: DELETE_DRAFT_SUCCESS,
+      name: 'draft',
+      update: fetchDrafts(directory),
+    },
+    { type: DELETE_DRAFT_FAILURE, name: 'error' },
+    dispatch
+  );
 };
 
 export const publishDraft = (directory, filename) => (dispatch, getState) => {

--- a/src/ducks/drafts.js
+++ b/src/ducks/drafts.js
@@ -3,7 +3,7 @@ import { CLEAR_ERRORS, validationError } from './utils';
 import { PUT_DOCUMENT_SUCCESS, PUT_DOCUMENT_FAILURE } from './collections';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
-import { slugify, trimObject } from '../utils/helpers';
+import { slugify, trimObject, computeRelativePath } from '../utils/helpers';
 import { draftsAPIUrl, draftAPIUrl, documentAPIUrl } from '../constants/api';
 
 import translations from '../translations';
@@ -90,13 +90,10 @@ export const putDraft = (mode, directory, filename = '') => (
 };
 
 export const deleteDraft = (directory, filename) => dispatch => {
+  const relative_path = computeRelativePath(directory, filename);
   return del(
     draftAPIUrl(directory, filename),
-    {
-      type: DELETE_DRAFT_SUCCESS,
-      name: 'draft',
-      update: fetchDrafts(directory),
-    },
+    { type: DELETE_DRAFT_SUCCESS, name: 'draft', id: relative_path },
     { type: DELETE_DRAFT_FAILURE, name: 'error' },
     dispatch
   );
@@ -178,6 +175,11 @@ export default function drafts(
         ...state,
         draft: action.draft,
         updated: true,
+      };
+    case DELETE_DRAFT_SUCCESS:
+      return {
+        ...state,
+        drafts: state.drafts.filter(d => d.relative_path !== action.id),
       };
     default:
       return {

--- a/src/ducks/drafts.js
+++ b/src/ducks/drafts.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { CLEAR_ERRORS, validationError } from './utils';
+import { CLEAR_ERRORS, validationError, filterDeleted } from './utils';
 import { PUT_DOCUMENT_SUCCESS, PUT_DOCUMENT_FAILURE } from './collections';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
@@ -179,7 +179,7 @@ export default function drafts(
     case DELETE_DRAFT_SUCCESS:
       return {
         ...state,
-        drafts: state.drafts.filter(d => d.relative_path !== action.id),
+        drafts: filterDeleted(state.drafts, action.id),
       };
     default:
       return {

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { CLEAR_ERRORS, validationError } from './utils';
+import { CLEAR_ERRORS, validationError, filterDeleted } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject, computeRelativePath } from '../utils/helpers';
@@ -176,7 +176,7 @@ export default function pages(
     case DELETE_PAGE_SUCCESS:
       return {
         ...state,
-        pages: state.pages.filter(p => p.relative_path !== action.id),
+        pages: filterDeleted(state.pages, action.id),
       };
     default:
       return {

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import { CLEAR_ERRORS, validationError } from './utils';
-import { get, put } from '../utils/fetch';
+import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject } from '../utils/helpers';
 import { pagesAPIUrl, pageAPIUrl } from '../constants/api';
@@ -104,20 +104,12 @@ export const putPage = (directory, filename) => (dispatch, getState) => {
 };
 
 export const deletePage = (directory, filename) => dispatch => {
-  return fetch(pageAPIUrl(directory, filename), {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-    .then(data => {
-      dispatch({ type: DELETE_PAGE_SUCCESS });
-      dispatch(fetchPages(directory));
-    })
-    .catch(error =>
-      dispatch({
-        type: DELETE_PAGE_FAILURE,
-        error,
-      })
-    );
+  return del(
+    pageAPIUrl(directory, filename),
+    { type: DELETE_PAGE_SUCCESS, name: 'page', update: fetchPages(directory) },
+    { type: DELETE_PAGE_FAILURE, name: 'error' },
+    dispatch
+  );
 };
 
 const validatePage = metadata =>

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -2,7 +2,7 @@ import _ from 'underscore';
 import { CLEAR_ERRORS, validationError } from './utils';
 import { get, put, del } from '../utils/fetch';
 import { validator } from '../utils/validation';
-import { slugify, trimObject } from '../utils/helpers';
+import { slugify, trimObject, computeRelativePath } from '../utils/helpers';
 import { pagesAPIUrl, pageAPIUrl } from '../constants/api';
 
 import translations from '../translations';
@@ -104,9 +104,10 @@ export const putPage = (directory, filename) => (dispatch, getState) => {
 };
 
 export const deletePage = (directory, filename) => dispatch => {
+  const relative_path = computeRelativePath(directory, filename);
   return del(
     pageAPIUrl(directory, filename),
-    { type: DELETE_PAGE_SUCCESS, name: 'page', update: fetchPages(directory) },
+    { type: DELETE_PAGE_SUCCESS, name: 'page', id: relative_path },
     { type: DELETE_PAGE_FAILURE, name: 'error' },
     dispatch
   );
@@ -171,6 +172,11 @@ export default function pages(
         ...state,
         page: action.page,
         updated: true,
+      };
+    case DELETE_PAGE_SUCCESS:
+      return {
+        ...state,
+        pages: state.pages.filter(p => p.relative_path !== action.id),
       };
     default:
       return {

--- a/src/ducks/staticfiles.js
+++ b/src/ducks/staticfiles.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { filterDeleted } from './utils';
 import { get, del } from '../utils/fetch';
 import { computeRelativePath } from '../utils/helpers';
 import { addNotification } from './notifications';
@@ -125,6 +126,11 @@ export default function staticfiles(
       return {
         ...state,
         uploading: false,
+      };
+    case DELETE_STATICFILE_SUCCESS:
+      return {
+        ...state,
+        files: filterDeleted(state.files, action.id),
       };
     default:
       return state;

--- a/src/ducks/staticfiles.js
+++ b/src/ducks/staticfiles.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import { get } from '../utils/fetch';
+import { get, del } from '../utils/fetch';
 import { addNotification } from './notifications';
 import { staticfilesAPIUrl, staticfileAPIUrl } from '../constants/api';
 
@@ -75,20 +75,16 @@ export const uploadStaticFiles = (directory, files) => dispatch => {
 };
 
 export const deleteStaticFile = (directory, filename) => dispatch => {
-  return fetch(staticfileAPIUrl(directory, filename), {
-    method: 'DELETE',
-    credentials: 'same-origin',
-  })
-    .then(data => {
-      dispatch({ type: DELETE_STATICFILE_SUCCESS });
-      dispatch(fetchStaticFiles(directory));
-    })
-    .catch(error =>
-      dispatch({
-        type: DELETE_STATICFILE_FAILURE,
-        error,
-      })
-    );
+  return del(
+    staticfileAPIUrl(directory, filename),
+    {
+      type: DELETE_STATICFILE_SUCCESS,
+      name: 'file',
+      update: fetchStaticFiles(directory),
+    },
+    { type: DELETE_STATICFILE_FAILURE, name: 'error' },
+    dispatch
+  );
 };
 
 // Reducer

--- a/src/ducks/staticfiles.js
+++ b/src/ducks/staticfiles.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import { get, del } from '../utils/fetch';
+import { computeRelativePath } from '../utils/helpers';
 import { addNotification } from './notifications';
 import { staticfilesAPIUrl, staticfileAPIUrl } from '../constants/api';
 
@@ -75,13 +76,10 @@ export const uploadStaticFiles = (directory, files) => dispatch => {
 };
 
 export const deleteStaticFile = (directory, filename) => dispatch => {
+  const relative_path = computeRelativePath(directory, filename);
   return del(
     staticfileAPIUrl(directory, filename),
-    {
-      type: DELETE_STATICFILE_SUCCESS,
-      name: 'file',
-      update: fetchStaticFiles(directory),
-    },
+    { type: DELETE_STATICFILE_SUCCESS, name: 'file', id: relative_path },
     { type: DELETE_STATICFILE_FAILURE, name: 'error' },
     dispatch
   );

--- a/src/ducks/utils.js
+++ b/src/ducks/utils.js
@@ -6,6 +6,10 @@ export const filterBySearchInput = (list, input) => {
   return list;
 };
 
+export const filterDeleted = (list, id) => {
+  return list.filter(item => item.relative_path !== id);
+};
+
 // Action Types
 export const SEARCH_CONTENT = 'SEARCH_CONTENT';
 export const CLEAR_ERRORS = 'CLEAR_ERRORS';

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -93,12 +93,12 @@ export const del = (url, action_success, action_failure, dispatch) => {
     method: 'DELETE',
     credentials: 'same-origin',
   })
-    .then(data => {
+    .then(data =>
       dispatch({
         type: action_success.type,
         id: action_success.id,
-      });
-    })
+      })
+    )
     .catch(error => {
       dispatch({
         type: action_failure.type,

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -7,7 +7,7 @@ const {
   getErrorMessage,
   getFetchErrorMessage,
   getUpdateErrorMessage,
-  getDeleteMessage,
+  getDeleteErrorMessage,
 } = translations;
 
 /**
@@ -93,12 +93,10 @@ export const del = (url, action_success, action_failure, dispatch) => {
     method: 'DELETE',
     credentials: 'same-origin',
   })
-    .then(data =>
-      dispatch({
-        type: action_success.type,
-        id: action_success.id,
-      })
-    )
+    .then(data => {
+      dispatch({ type: action_success.type });
+      dispatch(action_success.update);
+    })
     .catch(error => {
       dispatch({
         type: action_failure.type,
@@ -107,7 +105,7 @@ export const del = (url, action_success, action_failure, dispatch) => {
       dispatch(
         addNotification(
           getErrorMessage(),
-          getDeleteMessage(action_success.name),
+          getDeleteErrorMessage(action_success.name),
           'error'
         )
       );

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -94,8 +94,10 @@ export const del = (url, action_success, action_failure, dispatch) => {
     credentials: 'same-origin',
   })
     .then(data => {
-      dispatch({ type: action_success.type });
-      dispatch(action_success.update);
+      dispatch({
+        type: action_success.type,
+        id: action_success.id,
+      });
     })
     .catch(error => {
       dispatch({

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -155,3 +155,12 @@ export const getDocumentTitle = (type, splat, prefix = '') => {
   const label = toTitleCase(type.toString());
   return [prefix, splat, label].filter(Boolean).join(' | ');
 };
+
+/**
+ * @param {String} directory - Directory splat for current resource.
+ * @param {String} filename - Basename of current resource.
+ * @return {String} Filename or directory splat joined to the filename.
+ */
+export const computeRelativePath = (directory, filename) => {
+  return directory ? `${directory}/${filename}` : `${filename}`;
+};


### PR DESCRIPTION
Currently, a `fetch` wrapper for `DELETE` requests, is left unused.
Using the wrapper with slight modifications will bring consistency with `GET` and `PUT` requests that are sent via respective wrappers.