### PR TITLE
Prevent unexpected file overwrites for collections, drafts and pages

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -77,7 +77,11 @@ module JekyllAdmin
     end
 
     def ensure_not_file(file)
-      render_404 unless file.nil?
+      return if file.nil?
+
+      Jekyll.logger.warn "Jekyll Admin:", "Could not create file."
+      Jekyll.logger.warn "", "Path #{file.relative_path.inspect} already exists!"
+      render_404
     end
 
     def ensure_directory

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -52,7 +52,7 @@ module JekyllAdmin
       ensure_file(written_file)
     end
 
-    def ensure_not_written_file
+    def ensure_not_overwriting_existing_file
       ensure_not_file(written_file)
     end
 

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -52,6 +52,10 @@ module JekyllAdmin
       ensure_file(written_file)
     end
 
+    def ensure_not_written_file
+      ensure_not_file(written_file)
+    end
+
     def find_by_path(path)
       files = case namespace
               when "collections"
@@ -70,6 +74,10 @@ module JekyllAdmin
 
     def ensure_file(file)
       render_404 if file.nil?
+    end
+
+    def ensure_not_file(file)
+      render_404 unless file.nil?
     end
 
     def ensure_directory

--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -53,9 +53,7 @@ module JekyllAdmin
 
     # Is this request creating a new file?
     def new?
-      return false if request_payload["path"]
-
-      ensure_leading_slash(request_payload["path"]) != relative_path
+      !request_payload["path"]
     end
 
     private

--- a/lib/jekyll-admin/path_helper.rb
+++ b/lib/jekyll-admin/path_helper.rb
@@ -51,6 +51,13 @@ module JekyllAdmin
       ensure_leading_slash(request_payload["path"]) != relative_path
     end
 
+    # Is this request creating a new file?
+    def new?
+      return false if request_payload["path"]
+
+      ensure_leading_slash(request_payload["path"]) != relative_path
+    end
+
     private
 
     # Returns the path to the requested file's containing directory

--- a/lib/jekyll-admin/server/collections.rb
+++ b/lib/jekyll-admin/server/collections.rb
@@ -25,6 +25,8 @@ module JekyllAdmin
       put "/:collection_id/*?/?:path.:ext" do
         ensure_collection
 
+        ensure_not_written_file if new? || renamed?
+
         if renamed?
           ensure_requested_file
           delete_file_without_process path

--- a/lib/jekyll-admin/server/collections.rb
+++ b/lib/jekyll-admin/server/collections.rb
@@ -25,10 +25,11 @@ module JekyllAdmin
       put "/:collection_id/*?/?:path.:ext" do
         ensure_collection
 
-        ensure_not_written_file if new? || renamed?
-
-        if renamed?
+        if new?
+          ensure_not_overwriting_existing_file
+        elsif renamed?
           ensure_requested_file
+          ensure_not_overwriting_existing_file
           delete_file_without_process path
         end
 

--- a/lib/jekyll-admin/server/drafts.rb
+++ b/lib/jekyll-admin/server/drafts.rb
@@ -16,6 +16,8 @@ module JekyllAdmin
       put "/*?/?:path.:ext" do
         ensure_html_content
 
+        ensure_not_written_file if new? || renamed?
+
         if renamed?
           ensure_requested_file
           delete_file_without_process path

--- a/lib/jekyll-admin/server/drafts.rb
+++ b/lib/jekyll-admin/server/drafts.rb
@@ -16,10 +16,11 @@ module JekyllAdmin
       put "/*?/?:path.:ext" do
         ensure_html_content
 
-        ensure_not_written_file if new? || renamed?
-
-        if renamed?
+        if new?
+          ensure_not_overwriting_existing_file
+        elsif renamed?
           ensure_requested_file
+          ensure_not_overwriting_existing_file
           delete_file_without_process path
         end
 

--- a/lib/jekyll-admin/server/pages.rb
+++ b/lib/jekyll-admin/server/pages.rb
@@ -16,6 +16,8 @@ module JekyllAdmin
       put "/*?/?:path.:ext" do
         ensure_html_content
 
+        ensure_not_written_file if new? || renamed?
+
         if renamed?
           ensure_requested_file
           delete_file_without_process path

--- a/lib/jekyll-admin/server/pages.rb
+++ b/lib/jekyll-admin/server/pages.rb
@@ -16,15 +16,15 @@ module JekyllAdmin
       put "/*?/?:path.:ext" do
         ensure_html_content
 
-        ensure_not_written_file if new? || renamed?
-
-        if renamed?
+        if new?
+          ensure_not_overwriting_existing_file
+        elsif renamed?
           ensure_requested_file
+          ensure_not_overwriting_existing_file
           delete_file_without_process path
         end
 
         write_file write_path, page_body
-
         json written_file.to_api(:include_content => true)
       end
 

--- a/spec/jekyll-admin/server/collection_spec.rb
+++ b/spec/jekyll-admin/server/collection_spec.rb
@@ -267,6 +267,7 @@ describe "collections" do
     write_file "_posts/2016-01-01-test2.md"
 
     request = {
+      :path         => "_posts/2016-01-01-test2.md",
       :front_matter => { :foo => "bar2" },
       :raw_content  => "test",
     }
@@ -283,6 +284,7 @@ describe "collections" do
     write_file "_posts/more posts/2016-01-01-test2.md"
 
     request = {
+      :path         => "_posts/more posts/2016-01-01-test2.md",
       :front_matter => { :foo => "bar2" },
       :raw_content  => "test",
     }


### PR DESCRIPTION
For collections, drafts and pages, return a 404 if a new or renamed item will overwrite an existing item.

Fixes #489 .

Let me know if this looks like the right approach.

Two existing tests were altered to match what I was seeing during manual testing. New tests not written yet, I'll wait until I get some feedback on the changes.