### PR TITLE
Accept additional arguments in script/test-server

### DIFF
--- a/script/test-server
+++ b/script/test-server
@@ -5,4 +5,4 @@ set -e
 script/branding
 
 cd ./spec/fixtures/site || exit
-RACK_ENV=development bundle exec jekyll serve --verbose --watch
+RACK_ENV=development bundle exec jekyll serve --verbose --watch "$@"


### PR DESCRIPTION
This allows for overriding defaults.

For example: `./script/test-server --host 127.0.0.1 --port 4000`

Signed-off-by: alzeih <alzeih@users.noreply.github.com>