### PR TITLE
Use the front matter defaults computed by Jekyll

### DIFF
--- a/docs/_frontend/containers.md
+++ b/docs/_frontend/containers.md
@@ -284,8 +284,7 @@ Container for editing a draft.
   errors: Array,
   params: Object,
   router: Object,
-  route: Object,
-  config: Object
+  route: Object
 }
 ```
 

--- a/lib/jekyll-admin/apiable.rb
+++ b/lib/jekyll-admin/apiable.rb
@@ -134,6 +134,16 @@ module JekyllAdmin
       Jekyll::Utils.merged_file_read_opts(site, {})
     end
 
+    def front_matter_defaults
+      return unless file_exists?
+
+      @front_matter_defaults ||= begin
+        return {} unless respond_to?(:relative_path) && respond_to?(:type)
+
+        site.frontmatter_defaults.all(relative_path, type)
+      end
+    end
+
     def front_matter
       return unless file_exists?
 
@@ -187,6 +197,7 @@ module JekyllAdmin
       else
         output["raw_content"] = raw_content
         output["front_matter"] = front_matter
+        output["front_matter_defaults"] = front_matter_defaults
       end
 
       # Include next and previous documents non-recursively

--- a/src/containers/views/DocumentEdit.js
+++ b/src/containers/views/DocumentEdit.js
@@ -18,7 +18,6 @@ import {
 } from '../../ducks/collections';
 import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { clearErrors } from '../../ducks/utils';
-import { injectDefaultFields } from '../../utils/metadata';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
 import { ADMIN_PREFIX } from '../../constants';
 
@@ -95,7 +94,6 @@ export class DocumentEdit extends Component {
       updated,
       fieldChanged,
       params,
-      config,
     } = this.props;
 
     if (isFetching) {
@@ -112,10 +110,10 @@ export class DocumentEdit extends Component {
       http_url,
       collection,
       front_matter,
+      front_matter_defaults,
       name,
     } = currentDocument;
     const directory = params.splat[0];
-    const defaultMetadata = injectDefaultFields(config, directory, collection);
 
     const keyboardHandlers = {
       save: this.handleClickSave,
@@ -143,7 +141,7 @@ export class DocumentEdit extends Component {
               updateBody={updateBody}
               onSave={this.handleClickSave}
               metafields={{ title, path: name, raw_content, ...front_matter }}
-              staticmetafields={defaultMetadata}
+              staticmetafields={front_matter_defaults}
             />
             <div className="content-side">
               <Button
@@ -185,7 +183,6 @@ DocumentEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -194,7 +191,6 @@ const mapStateToProps = state => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.collections.updated,
   errors: state.utils.errors,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/containers/views/DraftEdit.js
+++ b/src/containers/views/DraftEdit.js
@@ -20,7 +20,6 @@ import {
 } from '../../ducks/drafts';
 import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { clearErrors } from '../../ducks/utils';
-import { injectDefaultFields } from '../../utils/metadata';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
 import { ADMIN_PREFIX } from '../../constants';
 
@@ -118,7 +117,6 @@ export class DraftEdit extends Component {
       updated,
       fieldChanged,
       params,
-      config,
     } = this.props;
 
     if (isFetching) {
@@ -135,13 +133,12 @@ export class DraftEdit extends Component {
       name,
       path,
       raw_content,
-      collection,
       http_url,
       front_matter,
+      front_matter_defaults,
     } = draft;
     const directory = params.splat[0];
     const title = front_matter && front_matter.title ? front_matter.title : '';
-    const defaultMetadata = injectDefaultFields(config, directory, collection);
     const document_title = getDocumentTitle('drafts', directory, title || name);
 
     return (
@@ -163,7 +160,7 @@ export class DraftEdit extends Component {
               updateTitle={updateTitle}
               onSave={this.handleClickSave}
               metafields={{ title, raw_content, path: name, ...front_matter }}
-              staticmetafields={defaultMetadata}
+              staticmetafields={front_matter_defaults}
             />
             <div className="content-side">
               <Button
@@ -212,7 +209,6 @@ DraftEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -221,7 +217,6 @@ const mapStateToProps = state => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.drafts.updated,
   errors: state.utils.errors,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -14,7 +14,6 @@ import MarkdownPageBody from '../../components/MarkdownPageBody';
 import { fetchPage, deletePage, putPage } from '../../ducks/pages';
 import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { clearErrors } from '../../ducks/utils';
-import { injectDefaultFields } from '../../utils/metadata';
 import { preventDefault, getDocumentTitle } from '../../utils/helpers';
 import { ADMIN_PREFIX } from '../../constants';
 
@@ -85,7 +84,6 @@ export class PageEdit extends Component {
       updated,
       fieldChanged,
       params,
-      config,
     } = this.props;
 
     if (isFetching) {
@@ -100,12 +98,16 @@ export class PageEdit extends Component {
       save: this.handleClickSave,
     };
 
-    const { name, raw_content, http_url, front_matter } = page;
+    const {
+      name,
+      raw_content,
+      http_url,
+      front_matter,
+      front_matter_defaults,
+    } = page;
     const directory = params.splat[0];
 
     const title = front_matter && front_matter.title ? front_matter.title : '';
-    const defaultMetadata = injectDefaultFields(config, directory, 'pages');
-
     const document_title = getDocumentTitle('pages', directory, title || name);
 
     return (
@@ -128,7 +130,7 @@ export class PageEdit extends Component {
               title={title}
               body={raw_content}
               metafields={{ title, raw_content, path: name, ...front_matter }}
-              staticmetafields={defaultMetadata}
+              staticmetafields={front_matter_defaults}
             />
             <div className="content-side">
               <Button
@@ -170,7 +172,6 @@ PageEdit.propTypes = {
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -179,7 +180,6 @@ const mapStateToProps = state => ({
   fieldChanged: state.metadata.fieldChanged,
   updated: state.pages.updated,
   errors: state.utils.errors,
-  config: state.config.config,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/containers/views/tests/documentedit.spec.js
+++ b/src/containers/views/tests/documentedit.spec.js
@@ -5,10 +5,9 @@ import { DocumentEdit } from '../DocumentEdit';
 import Errors from '../../../components/Errors';
 import Button from '../../../components/Button';
 
-import { config, doc } from './fixtures';
+import { doc } from './fixtures';
 
 const defaultProps = {
-  config,
   currentDocument: doc,
   errors: [],
   fieldChanged: false,

--- a/src/containers/views/tests/pageedit.spec.js
+++ b/src/containers/views/tests/pageedit.spec.js
@@ -5,11 +5,10 @@ import { PageEdit } from '../PageEdit';
 import Errors from '../../../components/Errors';
 import Button from '../../../components/Button';
 
-import { config, page } from './fixtures';
+import { page } from './fixtures';
 
 const defaultProps = {
   page,
-  config,
   errors: [],
   fieldChanged: false,
   updated: false,


### PR DESCRIPTION
Jekyll already computes front matter defaults by comparing against `path` and `type` for a given resource.
However, the front-end port is still necessary for `"(**/)new"` routes, as the resource-path is undefined by default.