### PR TITLE
Fix listing static files in index view

### DIFF
--- a/src/components/FilePreview.js
+++ b/src/components/FilePreview.js
@@ -34,11 +34,20 @@ export default class FilePreview extends Component {
     }
   }
 
+  get isImageFile() {
+    const {
+      file: { type, extname },
+    } = this.props;
+    if (type === 'directory') {
+      return false;
+    }
+
+    return /png|jpg|gif|jpeg|svg|ico/i.test(extname.substring(1));
+  }
+
   render() {
     const { onClick, file, splat } = this.props;
-    const extension = file.extname.substring(1);
-    const image = /png|jpg|gif|jpeg|svg|ico/i.test(extension);
-    const node = image ? (
+    const node = this.isImageFile ? (
       <img src={file.http_url} alt={file.relative_path} />
     ) : (
       <div>


### PR DESCRIPTION
Since directories do not have `extname`, when switched to index listing, `FilePreview` was throwing an error saying `file.extname` is undefined. Fixed it by checking file type before accessing `extname`.