### PR TITLE
Processes site when writing file

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -22,12 +22,7 @@ module JekyllAdmin
       File.open(path, "wb") do |file|
         file.write(content)
       end
-      # we should fully process in dev mode for tests to pass
-      if ENV["RACK_ENV"] == "production"
-        site.read
-      else
-        site.process
-      end
+      site.process
     end
 
     # Delete the file at the given path


### PR DESCRIPTION
This PR seeks to address https://github.com/jekyll/jekyll-admin/issues/623.

Resolved #623

Instead of reading the entire site, which could lead to duplicating files, I opted to just re-process the site.