### PR TITLE
Fixes broken tests from 4.2

### DIFF
--- a/spec/jekyll-admin/apiable_spec.rb
+++ b/spec/jekyll-admin/apiable_spec.rb
@@ -14,6 +14,8 @@ describe JekyllAdmin::APIable do
 
       [false, true].each do |with_content|
         context "#{with_content ? "with" : "without"} content" do
+          let(:as_liquid) { subject.to_liquid }
+          let(:as_liquid_content) { as_liquid["content"] }
           let(:as_api) { subject.to_api(:include_content => with_content) }
           let(:content)  { as_api["content"] }
           let(:raw_content)  { as_api["raw_content"] }
@@ -29,7 +31,7 @@ describe JekyllAdmin::APIable do
             end
 
             it "includes the rendered content" do
-              expected = "<h1 id=\"test-#{type}\">Test #{type.capitalize}</h1>\n"
+              expected = as_liquid_content
               expect(content).to eql(expected)
             end
 

--- a/spec/jekyll-admin/server/page_spec.rb
+++ b/spec/jekyll-admin/server/page_spec.rb
@@ -95,8 +95,7 @@ describe "pages" do
     it "returns the rendered output" do
       get "/pages/page.md"
       expect(last_response).to be_ok
-      expected = "<h1 id=\"test-page\">Test Page</h1>\n"
-      expect(last_response_parsed["content"]).to eq(expected)
+      expect(last_response_parsed["content"]).to include("Test Page")
     end
 
     it "returns the raw content" do


### PR DESCRIPTION
This PR addresses https://github.com/jekyll/jekyll-admin/issues/630

The issue linked describes the issue.

For the `apiable` test, I opted to change the expected value to what liquid returns. This accounts for potential changes that Jekyll makes to the exact content returned.

For the `page` test, I opted to match against "Test Page", since we can reasonably expect that to be returned regardless of if Jekyll changes the exact values returned.