### PR TITLE
Bump versions of Sinatra libraries

### DIFF
--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
-  spec.add_dependency "sinatra", "~> 1.4"
-  spec.add_dependency "sinatra-contrib", "~> 1.4"
+  spec.add_dependency "sinatra", "~> 2.1"
+  spec.add_dependency "sinatra-contrib", "~> 2.1"
 
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "gem-release", "~> 0.7"


### PR DESCRIPTION
To avert security vulnerabilities from using an older version of second-order dependency gem `rack`.