### PR TITLE
Added links buttons in header

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -35,3 +35,19 @@ Valid values for `homepage`: `pages` (default), `posts`, `<collection_name>`,
 jekyll_admin:
   homepage: "posts"
 ```
+
+
+#### `header_buttons`
+
+Add buttons in the header to open custom links. You may provide for each link:
+- `title`: the button label
+- `url`: the URL to be opened
+- `icon`: the fontawesome icon to be used (if none, the view icon will be used)
+
+```yaml
+jekyll_admin:
+  header_buttons:
+   - title: Google
+     url: 'https://www.google.com'
+     icon: search
+```

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -99,3 +99,9 @@ collections:
 
 jekyll_admin:
   homepage: "posts"
+  header_buttons:
+    - title: Google
+      url: 'https://www.google.fr'
+      icon: search
+    - title: Bing
+      url: 'https://www.bing.com'

--- a/spec/fixtures/site/page.md
+++ b/spec/fixtures/site/page.md
@@ -3,3 +3,5 @@ foo: bar
 ---
 
 # Test Page
+
+![]({{ 'assets/images/icon-github.svg' | relative_url }})

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -24,6 +24,7 @@ export default function Button({
   thin,
   icon,
   to,
+  label,
 }) {
   const btnClass = classnames('btn', {
     'btn-active': active,
@@ -35,25 +36,25 @@ export default function Button({
     'btn-thin': thin,
   });
 
-  let label, triggeredLabel;
+  let typeLabel, triggeredLabel;
   switch (type) {
     case 'save':
     case 'create':
-      label = labels[type].label;
+      typeLabel = labels[type].label;
       triggeredLabel = labels[type].triggeredLabel;
       break;
     case 'view-toggle':
-      label = labels.viewToggle.label;
+      typeLabel = labels.viewToggle.label;
       triggeredLabel = labels.viewToggle.triggeredLabel;
       break;
     case 'view':
     case 'delete':
     case 'upload':
     case 'publish':
-      label = labels[type].label;
+      typeLabel = labels[type].label;
       break;
     default:
-      label = '<LABEL>';
+      typeLabel = '<LABEL>';
       triggeredLabel = '<NEXT LABEL>';
   }
 
@@ -62,16 +63,21 @@ export default function Button({
 
   if (to) {
     return (
-      <a href={to} target="_blank" rel="noopener noreferrer" className={btnClass}>
+      <a
+        href={to}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={btnClass}
+      >
         {iconNode}
-        {label}
+        {label ?? typeLabel}
       </a>
     );
   } else if (onClick) {
     return (
       <button onClick={onClick} className={btnClass}>
         {iconNode}
-        {triggered ? triggeredLabel : label}
+        {label ?? (triggered ? triggeredLabel : typeLabel)}
       </button>
     );
   }

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import Icon from '../components/Icon';
+import Button from '../components/Button';
 
 export class Header extends Component {
   render() {
@@ -14,6 +15,22 @@ export class Header extends Component {
             <span>{config.title || 'You have no title!'}</span>
           </Link>
         </h3>
+        {config.jekyll_admin?.header_buttons && (
+          <span className="header_buttons">
+            {' '}
+            {config.jekyll_admin?.header_buttons.map((button, i) => (
+              <Button
+                key={'header_button_' + i}
+                active
+                thin
+                type="view"
+                to={button.url}
+                icon={button.icon}
+                label={button.title ?? 'Click me'}
+              />
+            ))}
+          </span>
+        )}
         <span className="version">v{process.env.REACT_APP_VERSION}</span>
       </div>
     );

--- a/src/containers/tests/__snapshots__/header.spec.js.snap
+++ b/src/containers/tests/__snapshots__/header.spec.js.snap
@@ -22,6 +22,23 @@ exports[`Containers::Header renders correctly 1`] = `
     </a>
   </h3>
   <span
+    className="header_buttons"
+  >
+     
+    <a
+      className="btn btn-active btn-view btn-thin"
+      href="https://www.google.fr"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <i
+        aria-hidden="true"
+        className="fa fa-search"
+      />
+      Google
+    </a>
+  </span>
+  <span
     className="version"
   >
     v

--- a/src/containers/tests/fixtures/index.js
+++ b/src/containers/tests/fixtures/index.js
@@ -1,57 +1,60 @@
 export const config = {
   content: {
-    title: "Your awesome title",
-    email: "your-email@domain.com",
-    baseurl: "",
-    url: "http://yourdomain.com"
+    title: 'Your awesome title',
+    email: 'your-email@domain.com',
+    baseurl: '',
+    url: 'http://yourdomain.com',
+    jekyll_admin: {
+      header_buttons: [
+        { title: 'Google', url: 'https://www.google.fr', icon: 'search' },
+      ],
+    },
   },
-  raw_content: "title: Your awesome title\nemail: your-email@domain.com\nbaseurl:\nurl: http://yourdomain.com"
+  raw_content:
+    "title: Your awesome title\nemail: your-email@domain.com\nbaseurl:\nurl: http://yourdomain.com\njekyll_admin:\n  header_buttons:\n    - title: Google\n      url: 'https://www.google.fr'\n      icon: search",
 };
 
 export const collections = [
   {
-    label: "posts",
-    path: "/posts"
+    label: 'posts',
+    path: '/posts',
   },
   {
-    label: "movies",
-    path: "/movies"
-  }
+    label: 'movies',
+    path: '/movies',
+  },
 ];
 
 export const content = {
-  content: "Body",
-  title: "GSoC",
-  layout: "post",
-  path: "gsoc.md",
-  categories: "gsoc",
+  content: 'Body',
+  title: 'GSoC',
+  layout: 'post',
+  path: 'gsoc.md',
+  categories: 'gsoc',
   students: [
-    "GSoC Students",
+    'GSoC Students',
     {
       name: {
-        first: "Mert",
-        last: "Kahyaoğlu"
+        first: 'Mert',
+        last: 'Kahyaoğlu',
       },
-      email: [
-        "mertkahyaoglu93@gmail.com",
-        "test@gmail.com"
-      ],
-      username: "mertkahyaoglu"
+      email: ['mertkahyaoglu93@gmail.com', 'test@gmail.com'],
+      username: 'mertkahyaoglu',
     },
     {
       name: {
-        first: "Ankur",
-        last: "Singh"
+        first: 'Ankur',
+        last: 'Singh',
       },
-      email: "ankur13019@iiitd.ac.in",
-      username: "rush-skills"
-    }
+      email: 'ankur13019@iiitd.ac.in',
+      username: 'rush-skills',
+    },
   ],
-  mentors: ["Ben Balter", "Jurgen Leschner", "Parker Moore"]
+  mentors: ['Ben Balter', 'Jurgen Leschner', 'Parker Moore'],
 };
 
 export const notification = {
   title: 'Test',
   message: 'Testing notifications',
-  level: 'success'
+  level: 'success',
 };

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -1,19 +1,24 @@
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   height: 60px;
   background-color: white;
   padding: 0 40px;
   border-bottom: 1px solid lighten($border-color, 9%);
   .title {
     font-weight: normal;
+    justify-self: flex-start;
+    flex: 1;
     a {
       color: #444444;
       &:hover {
         color: black;
       }
     }
+  }
+  .header_buttons {
+    margin: 0 5px;
   }
   .version {
     color: $inactive-gray;


### PR DESCRIPTION
Hello,

I am a new user to jekyll and I love jekyll-admin

This PR adds the ability to configure in _config.yml custom buttons in header to have some useful links when editing your site (for instance, I will add links to some free image libraries, to my web analytics, etc.)

![image](https://user-images.githubusercontent.com/3126751/198986080-48ca4b5b-bab7-4cb6-85bc-6b50c772eb8f.png)

#### `header_buttons`

Add buttons in the header to open custom links. You may provide for each link:
- `title`: the button label
- `url`: the URL to be opened
- `icon`: the fontawesome icon to be used (if none, the view icon will be used)

```yaml
jekyll_admin:
  header_buttons:
   - title: Google
     url: 'https://www.google.com'
     icon: search
```

Hope you will find this useful