### PR TITLE
Add force show drafts configuration option

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -35,3 +35,17 @@ Valid values for `homepage`: `pages` (default), `posts`, `<collection_name>`,
 jekyll_admin:
   homepage: "posts"
 ```
+
+
+#### `force_show_drafts`
+
+On some cases you want to use multiple config files or `--drafts` command line switch that won't be properly
+detected by jekyll-admin. This flag can force jekyll-admin to display the draft section in the sidebar
+even if `show_draft: true` hasn't been detected in the config file.
+
+It will only force display, not enable drafts. So be sure to have enabled drafts on jekyll.
+
+```yaml
+jekyll_admin:
+  force_show_drafts: true
+```

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -117,7 +117,10 @@ export class Sidebar extends Component {
 
     const collectionsPanel = this.renderCollections(hiddenLinks);
     const postsPanel = !hiddenLinks.includes('posts');
-    const draftsPanel = config && config.show_drafts;
+    const draftsPanel =
+      config &&
+      (config.show_drafts ||
+        (config.jekyll_admin && config.jekyll_admin.force_show_drafts));
 
     return (
       <div className="sidebar">


### PR DESCRIPTION
#### `force_show_drafts`

On some cases you want to use multiple config files or `--drafts` command line switch that won't be properly
detected by jekyll-admin. This flag can force jekyll-admin to display the draft section in the sidebar
even if `show_draft: true` hasn't been detected in the config file.

It will only force display, not enable drafts. So be sure to have enabled drafts on jekyll.

```yaml
jekyll_admin:
  force_show_drafts: true
```
