### PR TITLE
Added new_meta_defaults options

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -35,3 +35,22 @@ Valid values for `homepage`: `pages` (default), `posts`, `<collection_name>`,
 jekyll_admin:
   homepage: "posts"
 ```
+
+#### `new_meta_defaults`
+
+Add default values for meta fields of new drafts or posts.
+
+This is useful to define some meta fields that you want not to forget to set on your pages, but that do not have a default value given in `defaults` section of `_config.yml`.
+
+```yaml
+jekyll_admin:
+  new_meta_defaults:
+    date: ''
+    image: ''
+    tags: []
+    categories: []
+    ...
+```
+
+
+

--- a/spec/fixtures/site/_config.yml
+++ b/spec/fixtures/site/_config.yml
@@ -99,3 +99,8 @@ collections:
 
 jekyll_admin:
   homepage: "posts"
+  new_meta_defaults:
+    date: ''
+    image: ''
+    tags: []
+    categories: []

--- a/src/components/CreateMarkdownPage.js
+++ b/src/components/CreateMarkdownPage.js
@@ -37,6 +37,7 @@ export default function CreateMarkdownPage({
           updateBody={updateBody}
           onSave={onClickSave}
           staticmetafields={defaultFields(config, splat, metaType)}
+          metafields={config.content?.jekyll_admin?.new_meta_defaults}
         />
         <div className="content-side">
           <Button


### PR DESCRIPTION
This small PR adds the new_meta_defaults option to add new meta by default on new draft.

I know that jekyll-admin handle defaults settings of jekyll, but it not very handy as you have to define default values for things that does not make sense like date or others, and you need to click override to be able to modify it.