### PR TITLE
Fix duplicated entries bug

### DIFF
--- a/lib/jekyll-admin/directory.rb
+++ b/lib/jekyll-admin/directory.rb
@@ -12,9 +12,8 @@ module JekyllAdmin
     include JekyllAdmin::APIable
 
     RESOURCE_TYPES  = %w(pages data drafts static_files).freeze
-    DOT_DIRECTORIES = [".", ".."].freeze
 
-    private_constant :RESOURCE_TYPES, :DOT_DIRECTORIES
+    private_constant :RESOURCE_TYPES
 
     # Parameters:
     #   path - The full path of the directory at which its entries will be listed.
@@ -58,8 +57,7 @@ module JekyllAdmin
     end
 
     def directories
-      path.entries.map do |entry|
-        next if DOT_DIRECTORIES.include? entry.to_s
+      path.children.map do |entry|
         next unless path.join(entry).directory?
 
         self.class.new(


### PR DESCRIPTION
I was getting duplicated entries on my jekyll-admin instance for each content type (drafts, static files,...). I was not able to debug the ruby code to understand what was going on and it does not occur with the test site of jekyll-admin. But by replacing .entries method of Pathname with [.children](https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html#method-i-children) (that do not include dot directories) I have no more the duplicated entries issue.