### PR TITLE
Process site only if not in `watch` mode

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -22,14 +22,14 @@ module JekyllAdmin
       File.open(path, "wb") do |file|
         file.write(content)
       end
-      site.process
+      do_process
     end
 
     # Delete the file at the given path
     def delete_file(path)
       Jekyll.logger.debug "DELETING:", path
       FileUtils.rm_f sanitized_path(path)
-      site.process
+      do_process
     end
 
     def delete_file_without_process(path)
@@ -38,6 +38,10 @@ module JekyllAdmin
     end
 
     private
+
+    def do_process
+      site.process unless site.config['watch']  # to avoid race condition between jekyll watch and this
+    end
 
     def ensure_requested_file
       ensure_file(requested_file)

--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -22,14 +22,14 @@ module JekyllAdmin
       File.open(path, "wb") do |file|
         file.write(content)
       end
-      do_process
+      conditionally_process_site
     end
 
     # Delete the file at the given path
     def delete_file(path)
       Jekyll.logger.debug "DELETING:", path
       FileUtils.rm_f sanitized_path(path)
-      do_process
+      conditionally_process_site
     end
 
     def delete_file_without_process(path)
@@ -39,7 +39,7 @@ module JekyllAdmin
 
     private
 
-    def do_process
+    def conditionally_process_site
       site.process unless site.config['watch']  # to avoid race condition between jekyll watch and this
     end
 


### PR DESCRIPTION
Fix mentioned in #699 

Will avoid duplicate site processing: either we are in watch mode and jekyll-admin do not need to trigger site.process, or we are not in watch mode and jekyll-admin will trigger site.process

Note that it does not work when using `--livereload --no-watch` options simultaneously, which has little interest, as livereload option will force `config{"watch"]=1`.

Closes #699