### PR TITLE
Update sinatra version to resolve security vulnerabilities

### DIFF
--- a/jekyll-admin.gemspec
+++ b/jekyll-admin.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
-  spec.add_dependency "sinatra", ">= 1.4"
-  spec.add_dependency "sinatra-contrib", ">= 1.4"
+  spec.add_dependency "sinatra", ">= 1.4", "< 4.0"
+  spec.add_dependency "sinatra-contrib", ">= 1.4", "< 4.0"
 
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "gem-release", "~> 0.7"


### PR DESCRIPTION
This PR adopts @namiwang's [suggestion](https://github.com/jekyll/jekyll-admin/issues/705#issue-2120004694) to bump the version of `sinatra`, in order to resolve security vulnerabilities identified by Github Dependabot.

Upgrading `sinatra` to the latest version (`4.0.0`) requires more effort as mentioned in [this issue](https://github.com/jekyll/jekyll-admin/issues/705#issue-2120004694).