### PR TITLE
Bump `actions/checkout` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - "~> 4.0"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Ruby ${{ matrix.ruby_version }}"
         uses: ruby/setup-ruby@v1
         with:
@@ -41,7 +41,7 @@ jobs:
         node_version: ["12"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/gem_artifact.yml
+++ b/.github/workflows/gem_artifact.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Set up Ruby 2.7"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Bump `actions/checkout` to v4 in our workflows