### PR TITLE
Use Node v20 via `actions/setup-node@v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["12"]
+        node_version: ["20"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"


### PR DESCRIPTION
- Bump Node to v20.
- Bump `actions/setup-node` to v4.