### PR TITLE
Rewind `request.body` only when possible

### DIFF
--- a/lib/jekyll-admin/server.rb
+++ b/lib/jekyll-admin/server.rb
@@ -81,8 +81,9 @@ module JekyllAdmin
 
     def request_body
       @request_body ||= begin
-        request.body.rewind
-        request.body.read
+        rq_bdy = request.body
+        rq_bdy.rewind if rq_bdy.respond_to?(:rewind)
+        rq_bdy.read
       end
     end
 


### PR DESCRIPTION
With recent changes to use `rackup` lib directly, `request.body` is now `Rackup::Handler::WEBrick::Input` which does not respond to `:rewind` method. But our test mocks still do.