### PR TITLE
fix: Prevent NoMethodError on new post creation by forcing site read 

### DIFF
--- a/lib/jekyll-admin/file_helper.rb
+++ b/lib/jekyll-admin/file_helper.rb
@@ -22,6 +22,7 @@ module JekyllAdmin
       File.open(path, "wb") do |file|
         file.write(content)
       end
+      JekyllAdmin.site.read
       conditionally_process_site
     end
 


### PR DESCRIPTION
This pull request addresses a `NoMethodError` that occurs when creating a new post via Jekyll Admin.

**Problem:**
When a new post is saved, Jekyll Admin attempts to immediately load the new file into a `Jekyll::Document` instance for its API response. However, `JekyllAdmin.site`'s internal state has not yet been refreshed to include the newly written file. This results in `find_by_path` returning `nil`, leading to a `NoMethodError` when `to_api` is subsequently called. This issue also causes the UI alert "Could not update the doc," a symptom previously reported in #713 ).

For a detailed analysis and step-by-step reproduction, please refer to the associated issue: #726.