### PR TITLE
Bump `setup-node` action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: ["12"]
-    permissions: 
-      contents: write 
-      actions: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master]
+    branches: [master, ci-test]
   pull_request:
-    branches: [master]
+    branches: [master, ci-test]
 
 jobs:
   ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master, ci-test]
+    branches: [master, ci-test] 
   pull_request:
-    branches: [master, ci-test]
+    branches: [master, ci-test] 
 
 jobs:
   ruby:
@@ -39,11 +39,14 @@ jobs:
       fail-fast: false
       matrix:
         node_version: ["12"]
+    permissions: 
+      contents: write 
+      actions: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master] 
+    branches: [master]
   pull_request:
-    branches: [master] 
+    branches: [master]
 
 jobs:
   ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master, ci-test] 
+    branches: [master] 
   pull_request:
-    branches: [master, ci-test] 
+    branches: [master] 
 
 jobs:
   ruby:
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: "Set up Node ${{ matrix.node_version }}"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
           cache: "yarn"


### PR DESCRIPTION
This PR updates the CI workflow to use actions/setup-node@v3 instead of v2, as a preventive measure against potential cache restore failures.

While no error has occurred yet, recent changes in GitHub Actions caching infrastructure suggest that workflows relying on deprecated versions of actions/cache (used internally by setup-node@v2) 
Relevant discussions:

[actions/setup-node#1275](https://github.com/actions/setup-node/issues/1275)

[actions/toolkit/discussions/1890](https://github.com/actions/toolkit/discussions/1890)

if there’s a better approach or refinements needed, I’m happy to revise or close the PR as needed.

Thank you for your time and consideration!

Related Issue
Closes #728 